### PR TITLE
[FEAT] : 디버그 모드 추가 — collector 통신 없이 수집 데이터를 콘솔에 출력

### DIFF
--- a/agent-bootstrap/src/main/java/com/seeker/agent/bootstrap/AgentMain.java
+++ b/agent-bootstrap/src/main/java/com/seeker/agent/bootstrap/AgentMain.java
@@ -7,10 +7,13 @@ import com.seeker.agent.config.PropertiesLoader;
 import com.seeker.agent.core.context.ThreadLocalTraceContext;
 import com.seeker.agent.core.context.TraceContextHolder;
 import com.seeker.agent.core.model.AgentInfo;
+import com.seeker.agent.core.sender.AgentInfoSender;
 import com.seeker.agent.core.sender.DataSender;
 import com.seeker.agent.core.sender.DataSenderHolder;
 import com.seeker.agent.instrument.InstrumentEngine;
 import com.seeker.agent.sender.AsyncSpanDispatcher;
+import com.seeker.agent.sender.ConsoleAgentInfoSender;
+import com.seeker.agent.sender.ConsoleSpanTransport;
 import com.seeker.agent.sender.GrpcSpanTransport;
 import com.seeker.agent.sender.HttpAgentInfoSender;
 import com.seeker.agent.sender.SpanTransport;
@@ -42,7 +45,12 @@ public class AgentMain {
         ProfilerConfig profilerConfig = new ProfilerConfig(properties);
         System.out.println("[Seeker] 로드된 설정: " + identityConfig + ", " + collectorConfig + ", " + profilerConfig);
 
-        // Collector에 에이전트 등록 (HTTP)
+        boolean debugEnabled = profilerConfig.isDebugEnabled();
+        if (debugEnabled) {
+            System.out.println("[Seeker] DEBUG MODE ENABLED — collector 통신 차단, 수집 데이터를 콘솔에 출력");
+        }
+
+        // 에이전트 등록 (디버그 모드 시 콘솔, 평소 HTTP)
         long startTime = System.currentTimeMillis();
         AgentInfo agentInfo = new AgentInfo(
                 identityConfig.getAgentId(),
@@ -50,17 +58,22 @@ public class AgentMain {
                 identityConfig.getAgentType(),
                 identityConfig.getAgentGroup(),
                 startTime);
-        new HttpAgentInfoSender(collectorConfig.getHost(), collectorConfig.getHttpPort()).register(agentInfo);
+        AgentInfoSender agentInfoSender = debugEnabled
+                ? new ConsoleAgentInfoSender()
+                : new HttpAgentInfoSender(collectorConfig.getHost(), collectorConfig.getHttpPort());
+        agentInfoSender.register(agentInfo);
 
         // TraceContext 초기화 및 Holder에 등록
         TraceContextHolder.setTraceContext(new ThreadLocalTraceContext());
 
-        // DataSender 초기화 및 등록 (Dispatcher + Transport 조합)
-        SpanTransport transport = new GrpcSpanTransport(
-                collectorConfig.getHost(),
-                collectorConfig.getGrpcPort(),
-                identityConfig.getAgentName(),
-                identityConfig.getAgentId());
+        // DataSender 초기화 및 등록 (Dispatcher + Transport 조합, 디버그 모드 시 Transport는 콘솔)
+        SpanTransport transport = debugEnabled
+                ? new ConsoleSpanTransport()
+                : new GrpcSpanTransport(
+                        collectorConfig.getHost(),
+                        collectorConfig.getGrpcPort(),
+                        identityConfig.getAgentName(),
+                        identityConfig.getAgentId());
         DataSender sender = new AsyncSpanDispatcher(transport, 1024 * 8);
         DataSenderHolder.setSender(sender);
 

--- a/agent-config/src/main/java/com/seeker/agent/config/ProfilerConfig.java
+++ b/agent-config/src/main/java/com/seeker/agent/config/ProfilerConfig.java
@@ -16,6 +16,8 @@ public class ProfilerConfig {
     private final double samplingRate;
     // 특정 패키지 하위의 클래스를 추적할 base packages
     private final String basePackages;
+    // 디버그 모드: Collector에 연결하지 않고 수집 데이터를 콘솔에 출력
+    private final boolean debugEnabled;
 
     public ProfilerConfig(Properties properties) {
         this.jdbcEnabled = Boolean.parseBoolean(properties.getProperty("seeker.profiler.jdbc.enabled", "true"));
@@ -25,6 +27,7 @@ public class ProfilerConfig {
                 .parseInt(properties.getProperty("seeker.profiler.max-span-event-count", "1500"));
         this.samplingRate = Double.parseDouble(properties.getProperty("seeker.profiler.sampling-rate", "1.0"));
         this.basePackages = properties.getProperty("seeker.profiler.base-packages", "");
+        this.debugEnabled = Boolean.parseBoolean(properties.getProperty("seeker.profiler.debug.enabled", "false"));
     }
 
     public boolean isJdbcEnabled() {
@@ -51,6 +54,10 @@ public class ProfilerConfig {
         return basePackages;
     }
 
+    public boolean isDebugEnabled() {
+        return debugEnabled;
+    }
+
     @Override
     public String toString() {
         return "ProfilerConfig{" +
@@ -60,6 +67,7 @@ public class ProfilerConfig {
                 ", maxSpanEventCount=" + maxSpanEventCount +
                 ", samplingRate=" + samplingRate +
                 ", basePackages='" + basePackages + '\'' +
+                ", debugEnabled=" + debugEnabled +
                 '}';
     }
 }

--- a/agent-sender/src/main/java/com/seeker/agent/sender/ConsoleAgentInfoSender.java
+++ b/agent-sender/src/main/java/com/seeker/agent/sender/ConsoleAgentInfoSender.java
@@ -1,0 +1,16 @@
+package com.seeker.agent.sender;
+
+import com.seeker.agent.core.model.AgentInfo;
+import com.seeker.agent.core.sender.AgentInfoSender;
+
+/**
+ * 에이전트 정보를 콘솔에 출력하는 AgentInfoSender 구현체입니다.
+ * 디버그 모드에서 Collector HTTP 등록 호출 없이 등록 정보를 확인하는 용도로 사용됩니다.
+ */
+public class ConsoleAgentInfoSender implements AgentInfoSender {
+
+    @Override
+    public void register(AgentInfo info) {
+        System.out.println("[Seeker-DEBUG][AGENT_INFO] " + info);
+    }
+}

--- a/agent-sender/src/main/java/com/seeker/agent/sender/ConsoleSpanTransport.java
+++ b/agent-sender/src/main/java/com/seeker/agent/sender/ConsoleSpanTransport.java
@@ -1,0 +1,68 @@
+package com.seeker.agent.sender;
+
+import com.seeker.agent.core.model.MethodType;
+import com.seeker.agent.core.model.Span;
+import com.seeker.agent.core.model.SpanEvent;
+
+/**
+ * Span을 콘솔에 트리 형태로 출력하는 SpanTransport 구현체입니다.
+ * 디버그 모드에서 Collector 통신 없이 수집 데이터를 확인하는 용도로 사용됩니다.
+ */
+public class ConsoleSpanTransport implements SpanTransport {
+
+    public ConsoleSpanTransport() {
+        System.out.println("[Seeker] ConsoleSpanTransport 초기화 (collector 통신 없음)");
+    }
+
+    @Override
+    public void send(Span span) {
+        System.out.println("[Seeker-DEBUG][SPAN]\n" + format(span));
+    }
+
+    @Override
+    public void close() {
+        // no-op
+    }
+
+    private String format(Span span) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Span{")
+                .append("traceId=").append(span.getTraceId())
+                .append(", agentId=").append(span.getAgentId())
+                .append(", applicationName=").append(span.getApplicationName())
+                .append(", uri=").append(span.getUri())
+                .append(", endPoint=").append(span.getEndPoint())
+                .append(", serviceType=").append(span.getServiceType())
+                .append(", remoteAddr='").append(span.getRemoteAddr()).append('\'')
+                .append(", startTime=").append(span.getStartTime())
+                .append(", elapsedTime=").append(span.getElapsedTime()).append("ms")
+                .append(", spanEventCount=").append(span.getSpanEventList().size());
+        if (span.getExceptionInfo() != null) {
+            sb.append(", exceptionInfo=").append(span.getExceptionInfo());
+        }
+        sb.append('}');
+        for (SpanEvent event : span.getSpanEventList()) {
+            sb.append('\n').append(formatEvent(event));
+        }
+        return sb.toString();
+    }
+
+    private String formatEvent(SpanEvent event) {
+        StringBuilder indent = new StringBuilder();
+        for (int i = 1; i < event.getDepth(); i++) {
+            indent.append("  ");
+        }
+        StringBuilder sb = new StringBuilder();
+        sb.append(indent).append("└ SpanEvent#").append(event.getSequence())
+                .append(" depth=").append(event.getDepth())
+                .append(" type=").append(MethodType.fromCode(event.getMethodType()).name())
+                .append(" elapsed=").append(event.getElapsedTime()).append("ms");
+        if (event.getAttributes() != null && !event.getAttributes().isEmpty()) {
+            sb.append(" attributes=").append(event.getAttributes());
+        }
+        if (event.getException() != null) {
+            sb.append(" exception=").append(event.getException());
+        }
+        return sb.toString();
+    }
+}

--- a/seeker-test/src/main/resources/seeker.config
+++ b/seeker-test/src/main/resources/seeker.config
@@ -5,3 +5,5 @@ seeker.collector.host=127.0.0.1
 seeker.collector.grpc-port=9999
 seeker.collector.http-port=8081
 seeker.profiler.base-packages=com.seeker.test
+
+seeker.profiler.debug.enabled=false

--- a/seeker-test/src/main/resources/seeker.config
+++ b/seeker-test/src/main/resources/seeker.config
@@ -6,4 +6,4 @@ seeker.collector.grpc-port=9999
 seeker.collector.http-port=8081
 seeker.profiler.base-packages=com.seeker.test
 
-seeker.profiler.debug.enabled=false
+seeker.profiler.debug.enabled=true

--- a/seeker-test2/src/main/resources/seeker.config
+++ b/seeker-test2/src/main/resources/seeker.config
@@ -4,3 +4,5 @@ seeker.collector.host=127.0.0.1
 seeker.collector.grpc-port=9999
 seeker.collector.http-port=8081
 seeker.profiler.base-packages=com.seeker.test2
+
+seeker.profiler.debug.enabled=false

--- a/seeker-test2/src/main/resources/seeker.config
+++ b/seeker-test2/src/main/resources/seeker.config
@@ -5,4 +5,4 @@ seeker.collector.grpc-port=9999
 seeker.collector.http-port=8081
 seeker.profiler.base-packages=com.seeker.test2
 
-seeker.profiler.debug.enabled=false
+seeker.profiler.debug.enabled=true


### PR DESCRIPTION
## Summary

`seeker.profiler.debug.enabled=true` 설정 시 **Collector(HTTP/gRPC) 통신을 완전히 차단**하고 수집 데이터를 콘솔에 출력하는 디버그 모드를 추가했습니다. Collector 없이도 에이전트가 어떤 데이터를 모으는지 즉시 확인할 수 있습니다.

#8 (Dispatcher/Transport 분리)에서 마련한 추상화를 활용해, **구현체 swap만**으로 동작합니다.

## 설계 — 모델은 디버그를 모른다

| 클래스 | 디버그 모드를 아는가? |
|---|---|
| `seeker.config` 파일 | 키 한 줄로 표현 |
| `ProfilerConfig` | `debugEnabled` 필드 보유 |
| `AgentMain` | 분기 두 ternary에서만 ON/OFF 선택 |
| `ConsoleSpanTransport` / `ConsoleAgentInfoSender` | **자기 자신이 디버그 구현체임** |
| `Trace`, `Span`, `SpanEvent` | **모름** — `DataSender` 인터페이스만 호출 |
| `AsyncSpanDispatcher` | **모름** — `SpanTransport` 인터페이스만 호출 |
| `GrpcSpanTransport`, `HttpAgentInfoSender` | **모름** — 디버그 ON 시 인스턴스화조차 안 됨 |

→ 디버그 모드 책임이 두 Console* 클래스에만 갇혀 있고, 도메인 모델(Trace/Span/SpanEvent)과 dispatcher는 오염되지 않음.

## 변경 사항

**신규 (2개)**
- `agent-sender/.../ConsoleSpanTransport.java` — `SpanTransport` 구현. Span을 트리형으로 stdout에 출력 (depth 들여쓰기, attributes / exception 포함). `close()`는 no-op.
- `agent-sender/.../ConsoleAgentInfoSender.java` — `AgentInfoSender` 구현. AgentInfo를 stdout에 출력. HTTP 호출 없음.

**수정**
- `agent-config/.../ProfilerConfig.java` — `debugEnabled` 필드 + getter, 키 `seeker.profiler.debug.enabled` (기본 `false`), `toString()` 반영.
- `agent-bootstrap/.../AgentMain.java` — 부팅 시 `isDebugEnabled()` 분기로 두 sender swap. ON일 때 `[Seeker] DEBUG MODE ENABLED — collector 통신 차단` 로그.
- `seeker-test`/`seeker-test2`의 `seeker.config` — `seeker.profiler.debug.enabled=false` 기본값 추가.

## 디버그 ON 시 흐름 (요청 1건 처리)

1. `Trace.finish()` → `DataSenderHolder.getSender().send(span)` (변화 없음, 디버그 모름)
2. `AsyncSpanDispatcher.send()` → `queue.offer(span)` (변화 없음, 디버그 모름)
3. Worker 스레드가 `queue.take()` → `transport.send(span)` (변화 없음, 디버그 모름)
4. `transport`가 `ConsoleSpanTransport` → 트리형 포맷 후 `System.out.println`

운영 모드와 다른 점은 **3→4의 transport 인스턴스 종류뿐**. 큐/워커/스레드 모델은 동일하게 유지 → 디버그 환경에서 본 흐름이 운영에 그대로 통함.

## 출력 예시

```
[Seeker] DEBUG MODE ENABLED — collector 통신 차단, 수집 데이터를 콘솔에 출력
[Seeker] ConsoleSpanTransport 초기화 (collector 통신 없음)
[Seeker-DEBUG][AGENT_INFO] AgentInfo{...}
...
[Seeker-DEBUG][SPAN]
Span{traceId=..., uri=/api/users, elapsedTime=120ms, spanEventCount=3}
└ SpanEvent#0 depth=1 type=SERVLET elapsed=120ms
  └ SpanEvent#1 depth=2 type=METHOD elapsed=80ms attributes={...}
    └ SpanEvent#2 depth=3 type=METHOD elapsed=60ms attributes={...}
```

## 커밋 분할

각 커밋이 독립적으로 컴파일 가능하도록 분리:
1. `2628021` ConsoleSpanTransport / ConsoleAgentInfoSender 추가
2. `b019958` ProfilerConfig에 디버그 모드 플래그 추가
3. `7561235` AgentMain 분기 와이어링 + 테스트 설정 키 추가

## Test plan

- [x] `./gradlew build -x test` 통과

## 후속 작업 (이번 PR 범위 밖)

- 출력을 SLF4J 등 로거로 이관 (현재 `System.out`)
- 디버그 모드 전용 옵션 (출력 상세도, 특정 Span 필터링 등)
