### PR TITLE
[FEAT]  opentelemtry 표준에 맞춰 propargation 생성

### DIFF
--- a/agent-bootstrap/src/main/java/com/seeker/agent/bootstrap/AgentMain.java
+++ b/agent-bootstrap/src/main/java/com/seeker/agent/bootstrap/AgentMain.java
@@ -6,7 +6,10 @@ import com.seeker.agent.config.ProfilerConfig;
 import com.seeker.agent.config.PropertiesLoader;
 import com.seeker.agent.core.context.ThreadLocalTraceContext;
 import com.seeker.agent.core.context.TraceContextHolder;
+import com.seeker.agent.core.context.propagation.PropagatorHolder;
+import com.seeker.agent.core.context.propagation.W3CTraceContextPropagator;
 import com.seeker.agent.core.model.AgentInfo;
+import com.seeker.agent.core.model.AgentInfoHolder;
 import com.seeker.agent.core.sender.AgentInfoSender;
 import com.seeker.agent.core.sender.DataSender;
 import com.seeker.agent.core.sender.DataSenderHolder;
@@ -63,8 +66,14 @@ public class AgentMain {
                 : new HttpAgentInfoSender(collectorConfig.getHost(), collectorConfig.getHttpPort());
         agentInfoSender.register(agentInfo);
 
+        // 인터셉터가 분산 추적 헤더에 자기 agentId를 실어보내려면 전역 접근이 필요
+        AgentInfoHolder.set(agentInfo);
+
         // TraceContext 초기화 및 Holder에 등록
         TraceContextHolder.setTraceContext(new ThreadLocalTraceContext());
+
+        // 분산 추적 헤더 propagator 등록 (기본: W3C Trace Context)
+        PropagatorHolder.setPropagator(new W3CTraceContextPropagator());
 
         // DataSender 초기화 및 등록 (Dispatcher + Transport 조합, 디버그 모드 시 Transport는 콘솔)
         SpanTransport transport = debugEnabled

--- a/agent-core/src/main/java/com/seeker/agent/core/context/ThreadLocalTraceContext.java
+++ b/agent-core/src/main/java/com/seeker/agent/core/context/ThreadLocalTraceContext.java
@@ -17,7 +17,7 @@ public class ThreadLocalTraceContext implements TraceContext {
     }
 
     /**
-     * 새로운 트레이스를 생성합니다.
+     * 새로운 루트 트레이스를 생성합니다.
      */
     @Override
     public Trace newTraceObject() {
@@ -28,11 +28,13 @@ public class ThreadLocalTraceContext implements TraceContext {
     }
 
     /**
-     * 외부(부모)로부터 전달받은 TraceId를 이어받아 트레이스를 생성합니다.
+     * 외부에서 전달된 trace에 합류합니다. 자기 spanId는 로컬에서 새로 생성되고,
+     * 받은 parentSpanId가 자기 부모로 기록됩니다.
      */
     @Override
-    public Trace newTraceObject(TraceId traceId) {
-        Trace trace = new Trace(traceId, System.currentTimeMillis());
+    public Trace continueTraceObject(String traceId, long parentSpanId) {
+        TraceId tid = TraceId.continueWith(traceId, parentSpanId);
+        Trace trace = new Trace(tid, System.currentTimeMillis());
         traceHolder.set(trace);
         return trace;
     }

--- a/agent-core/src/main/java/com/seeker/agent/core/context/TraceContext.java
+++ b/agent-core/src/main/java/com/seeker/agent/core/context/TraceContext.java
@@ -3,9 +3,20 @@ package com.seeker.agent.core.context;
 import com.seeker.agent.core.model.Trace;
 
 public interface TraceContext {
+
+    /**
+     * 새로운 루트 trace를 시작한다.
+     */
     Trace newTraceObject();
 
-    Trace newTraceObject(TraceId traceId);
+    /**
+     * 외부에서 전달된 trace에 합류한다. 자기 spanId는 <strong>로컬에서 새로 생성</strong>되고,
+     * 받은 {@code parentSpanId}가 자기 부모로 기록된다.
+     *
+     * @param traceId      32-char hex 공유 trace 식별자
+     * @param parentSpanId 호출자의 spanId (자기 입장에서의 parentSpanId)
+     */
+    Trace continueTraceObject(String traceId, long parentSpanId);
 
     Trace currentTraceObject();
 

--- a/agent-core/src/main/java/com/seeker/agent/core/context/TraceId.java
+++ b/agent-core/src/main/java/com/seeker/agent/core/context/TraceId.java
@@ -1,29 +1,40 @@
 package com.seeker.agent.core.context;
 
-import java.util.UUID;
+import java.security.SecureRandom;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
- * 분산 추적의 핵심 식별자 묶음.
- * traceId(전체 요청 체인), spanId(현재 서버 호출), parentSpanId(나를 호출한 서버의 spanId)를 포함합니다.
+ * 분산 추적의 핵심 식별자 묶음. 순수 값 객체.
+ *
+ * <p>W3C Trace Context 호환을 위해 다음 표현을 따른다.
+ * <ul>
+ *   <li>{@code traceId} : 16바이트 → 32-char lowercase hex 문자열</li>
+ *   <li>{@code spanId}, {@code parentSpanId} : 64-bit long (gRPC proto 호환).
+ *       헤더로 직렬화될 때만 16-char hex로 변환된다.</li>
+ * </ul>
+ *
+ * <p>spanId는 항상 <strong>로컬에서 생성</strong>된다. 호출자는 자기 spanId를 wire로 보내고,
+ * 수신자는 받은 spanId를 자기 입장의 parentSpanId로 삼아 새 spanId를 부여받는다.
+ * (sender 측 pre-allocation 구조가 아님.)
+ *
+ * <p>헤더 직렬화/역직렬화는 {@link com.seeker.agent.core.context.propagation.TraceContextPropagator}에 위임한다.
  */
 public class TraceId {
+
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+    private static final char[] HEX = "0123456789abcdef".toCharArray();
 
     private final String traceId;
     private final long spanId;
     private final long parentSpanId;
 
     /**
-     * root Span일때의 Trace를 생성할때 해당 생성자를 사용한다.
+     * root Span일 때(루트 trace의 시작점)의 TraceId를 생성한다.
      */
-    // TODO traceId 를 생성을 할때는 UUID를 사용하지 않고 각 ID의 조합으로 수정을 한다.
     public TraceId() {
-        this(UUID.randomUUID().toString(), generateId(), -1);
+        this(generateTraceId(), generateSpanId(), -1);
     }
 
-    /**
-     * trace가 전파되어선 왔을때의 기존 traceId에 맞게 생성을 해준다.
-     */
     public TraceId(String traceId, long spanId, long parentSpanId) {
         this.traceId = traceId;
         this.spanId = spanId;
@@ -31,11 +42,11 @@ public class TraceId {
     }
 
     /**
-     * 다음 서버로 전파할 때 사용할 새로운 TraceId를 생성합니다.
-     * traceId는 유지되고, 현재 spanId가 부모 spanId가 되며, 새로운 spanId를 생성합니다.
+     * 외부에서 받은 trace에 합류할 때 사용하는 팩토리.
+     * 받은 {@code traceId}/{@code parentSpanId}는 그대로 두고, <strong>자기 spanId는 로컬에서 새로 생성</strong>한다.
      */
-    public TraceId getNextTraceId() {
-        return new TraceId(traceId, generateId(), spanId);
+    public static TraceId continueWith(String traceId, long parentSpanId) {
+        return new TraceId(traceId, generateSpanId(), parentSpanId);
     }
 
     public String getTraceId() {
@@ -50,38 +61,23 @@ public class TraceId {
         return parentSpanId;
     }
 
-    private static long generateId() {
-        return ThreadLocalRandom.current().nextLong();
-    }
-
-    public static TraceId from(String traceId, String spanIdStr, String parentSpanIdStr) {
-        long spanId = (spanIdStr != null) ? Long.parseLong(spanIdStr) : generateId();
-        long parentSpanId = (parentSpanIdStr != null) ? Long.parseLong(parentSpanIdStr) : -1;
-        return new TraceId(traceId, spanId, parentSpanId);
-    }
-
     /**
-     * TraceId 정보를 하나의 문자열로 인코딩합니다. (traceId,spanId,parentSpanId)
+     * W3C 표준에 맞는 16바이트(32 hex char) traceId 생성.
      */
-    public String encode() {
-        return traceId + "," + spanId + "," + parentSpanId;
-    }
-
-    /**
-     * 인코딩된 문자열로부터 TraceId 객체를 복구합니다.
-     */
-    public static TraceId decode(String encoded) {
-        if (encoded == null || encoded.isEmpty())
-            return null;
-        try {
-            String[] parts = encoded.split(",");
-            if (parts.length >= 3) {
-                return new TraceId(parts[0], Long.parseLong(parts[1]), Long.parseLong(parts[2]));
-            }
-        } catch (Exception ignored) {
-            // TODO 에러가 발생했을때 예외 처리
+    private static String generateTraceId() {
+        byte[] bytes = new byte[16];
+        SECURE_RANDOM.nextBytes(bytes);
+        char[] out = new char[32];
+        for (int i = 0; i < bytes.length; i++) {
+            int v = bytes[i] & 0xFF;
+            out[i * 2] = HEX[v >>> 4];
+            out[i * 2 + 1] = HEX[v & 0x0F];
         }
-        return null;
+        return new String(out);
+    }
+
+    private static long generateSpanId() {
+        return ThreadLocalRandom.current().nextLong();
     }
 
     @Override

--- a/agent-core/src/main/java/com/seeker/agent/core/context/propagation/HeaderGetter.java
+++ b/agent-core/src/main/java/com/seeker/agent/core/context/propagation/HeaderGetter.java
@@ -1,0 +1,29 @@
+package com.seeker.agent.core.context.propagation;
+
+/**
+ * 캐리어(C)로부터 헤더 값을 읽어오는 추상화.
+ *
+ * <p>캐리어란 헤더를 가진 모든 매개체를 가리킨다. 예시:
+ * <ul>
+ *   <li>{@code org.apache.catalina.connector.Request}      — Tomcat 서블릿 요청</li>
+ *   <li>{@code org.apache.http.HttpRequest}                 — Apache HttpClient 요청</li>
+ *   <li>{@code okhttp3.Request}                             — OkHttp 요청</li>
+ *   <li>{@code io.grpc.Metadata}                            — gRPC 메타데이터</li>
+ * </ul>
+ *
+ * <p>이 인터페이스를 통해 propagator는 특정 라이브러리의 타입을 알 필요 없이 동작한다.
+ * 라이브러리 의존성은 각 plugin 안의 어댑터(예: {@code HttpServletRequestGetter})에 격리된다.
+ *
+ * @param <C> 캐리어의 구체 타입 (Tomcat의 Request, OkHttp의 Request 등)
+ */
+public interface HeaderGetter<C> {
+
+    /**
+     * 캐리어에서 주어진 이름의 헤더 값을 반환한다.
+     *
+     * @param carrier 헤더를 보유한 운반체
+     * @param name    조회할 헤더 이름 (예: {@code "traceparent"})
+     * @return 헤더 값, 존재하지 않으면 {@code null}
+     */
+    String getHeader(C carrier, String name);
+}

--- a/agent-core/src/main/java/com/seeker/agent/core/context/propagation/HeaderSetter.java
+++ b/agent-core/src/main/java/com/seeker/agent/core/context/propagation/HeaderSetter.java
@@ -1,0 +1,27 @@
+package com.seeker.agent.core.context.propagation;
+
+/**
+ * 캐리어(C)에 헤더 값을 기록하는 추상화.
+ *
+ * <p>{@link HeaderGetter}와 쌍을 이루며, 둘 다 propagator를 특정 라이브러리 타입에서 분리시키는 역할을 한다.
+ * inject(보내는 쪽)에서는 {@code HeaderSetter}를, extract(받는 쪽)에서는 {@code HeaderGetter}를 사용한다.
+ *
+ * <p>구현체는 각 plugin의 adapter 패키지에 둔다 (예: {@code ApacheHttpRequestSetter}). 이렇게 해야
+ * agent-core가 라이브러리에 의존하지 않고, 새 라이브러리(OkHttp, gRPC 등) 추가가 plugin 단위로 독립된다.
+ *
+ * @param <C> 캐리어의 구체 타입 (Apache의 HttpRequest, OkHttp의 Request 등)
+ */
+public interface HeaderSetter<C> {
+
+    /**
+     * 캐리어에 주어진 이름/값으로 헤더를 설정한다.
+     *
+     * <p>구현체는 동일 헤더가 이미 존재하는 경우의 처리(덮어쓰기 vs 추가)를 캐리어 라이브러리의 관례에 맞게 결정해야 한다.
+     * 일반적으로 분산 추적 헤더는 중복되면 안 되므로 덮어쓰기가 안전하다.
+     *
+     * @param carrier 헤더를 기록할 운반체
+     * @param name    헤더 이름 (예: {@code "traceparent"})
+     * @param value   헤더 값
+     */
+    void setHeader(C carrier, String name, String value);
+}

--- a/agent-core/src/main/java/com/seeker/agent/core/context/propagation/PropagationContext.java
+++ b/agent-core/src/main/java/com/seeker/agent/core/context/propagation/PropagationContext.java
@@ -1,0 +1,175 @@
+package com.seeker.agent.core.context.propagation;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * 분산 추적 헤더에 실리는 컨텍스트의 도메인 표현 (W3C Trace Context).
+ *
+ * <p>이 클래스는 <strong>wire 표현</strong>이지 로컬 trace 상태가 아니다.
+ * <ul>
+ *   <li>inject 시: 호출자(local)가 자기 현재 spanId를 {@code parentSpanId}에 담아 보낸다.</li>
+ *   <li>extract 시: 수신자가 받은 spanId를 자기 입장에서의 parentSpanId로 해석한다.</li>
+ * </ul>
+ *
+ * <p>즉 wire의 "spanId 자리"는 항상 <em>호출자의 spanId = 수신자의 parentSpanId</em>를 의미한다.
+ * 자기 spanId는 수신자가 로컬에서 새로 생성한다 (sender 측 pre-allocation 없음).
+ *
+ * <p>왜 local의 {@code TraceId}와 분리되어 있는가?
+ * <ul>
+ *   <li>{@code TraceId}는 (traceId, mySpanId, myParentSpanId)의 <strong>local 상태</strong>.</li>
+ *   <li>{@code PropagationContext}는 (traceId, callerSpanId)의 <strong>wire 상태</strong>.</li>
+ *   <li>둘을 한 자료구조에 섞으면 "이 spanId가 누구 거지?"가 헷갈린다 → 분리.</li>
+ * </ul>
+ *
+ * <p>운반 필드:
+ * <ul>
+ *   <li>{@code traceId}      - traceparent로 운반되는 32-char hex 식별자 (16바이트)</li>
+ *   <li>{@code parentSpanId} - traceparent의 parent-id 자리에 운반되는 long (호출자의 현재 spanId)</li>
+ *   <li>{@code traceState}   - 벤더 전용 메타데이터(pAgentId 등)를 tracestate로 운반</li>
+ *   <li>{@code baggage}      - 애플리케이션 컨텍스트(userId 등)를 baggage로 운반</li>
+ * </ul>
+ *
+ * <p>불변(immutable) 객체 — 빌더로만 생성 가능. 인터셉터 사이에서 의도치 않은 mutation을 방지.
+ */
+public final class PropagationContext {
+
+    /**
+     * "비어있음(헤더 없음 또는 파싱 실패)" 상태를 나타내는 싱글톤.
+     * extract 실패 시 null 대신 이 값을 반환하여 호출부의 null 체크 부담을 없앤다.
+     */
+    private static final PropagationContext EMPTY =
+            new PropagationContext(null, -1, Collections.emptyMap(), Collections.emptyMap());
+
+    /** 32-char lowercase hex (16바이트). 분산 추적 체인 전체에서 동일하게 유지된다. */
+    private final String traceId;
+
+    /**
+     * wire의 spanId 자리에 실리는 값.
+     * <ul>
+     *   <li>inject 호출자 입장 → 자기 현재 spanId</li>
+     *   <li>extract 결과 입장 → 자기 부모(호출자)의 spanId</li>
+     * </ul>
+     * 명명을 {@code parentSpanId}로 한 이유: extract 결과를 그대로 사용하기 직관적이라서.
+     */
+    private final long parentSpanId;
+
+    /** tracestate에 실리는 벤더 전용 키-값 (예: pAgentId). 항상 unmodifiable. */
+    private final Map<String, String> traceState;
+
+    /** baggage에 실리는 애플리케이션 컨텍스트 (예: userId, tenantId). 항상 unmodifiable. */
+    private final Map<String, String> baggage;
+
+    /** private 생성자 — 외부에서는 {@link #builder()}로만 생성 가능. */
+    private PropagationContext(String traceId,
+                               long parentSpanId,
+                               Map<String, String> traceState,
+                               Map<String, String> baggage) {
+        this.traceId = traceId;
+        this.parentSpanId = parentSpanId;
+        this.traceState = traceState;
+        this.baggage = baggage;
+    }
+
+    /**
+     * 빈 컨텍스트(헤더 없음/실패)를 반환. 항상 같은 인스턴스 재사용 (메모리 절약).
+     */
+    public static PropagationContext empty() {
+        return EMPTY;
+    }
+
+    /** 새 컨텍스트를 만들 때 사용하는 빌더. */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * 이 컨텍스트가 비어있는지 (extract 실패/헤더 없음을 의미).
+     * 호출부에서 분기 처리에 사용한다.
+     */
+    public boolean isEmpty() {
+        return traceId == null;
+    }
+
+    public String getTraceId() {
+        return traceId;
+    }
+
+    public long getParentSpanId() {
+        return parentSpanId;
+    }
+
+    public Map<String, String> getTraceState() {
+        return traceState;
+    }
+
+    public Map<String, String> getBaggage() {
+        return baggage;
+    }
+
+    /**
+     * {@link PropagationContext} 빌더.
+     *
+     * <p>빌더를 둔 이유: 호출부가 traceId/parentSpanId만 채울 수도, tracestate/baggage까지 채울 수도 있다.
+     * 향후 필드(예: trace-flags) 추가 시에도 호환성 유지가 쉽다.
+     *
+     * <p>{@link LinkedHashMap}을 쓰는 이유: 헤더 직렬화 시 키 순서를 안정적으로 유지하기 위함
+     * (디버깅 시 헤더가 뒤섞여 보이는 걸 방지).
+     */
+    public static final class Builder {
+        private String traceId;
+        private long parentSpanId = -1;  // -1: 부모 없음(루트) 또는 미설정
+        private final Map<String, String> traceState = new LinkedHashMap<>();
+        private final Map<String, String> baggage = new LinkedHashMap<>();
+
+        /** 32-char hex traceId 설정. */
+        public Builder traceId(String traceId) {
+            this.traceId = traceId;
+            return this;
+        }
+
+        /**
+         * wire의 spanId 자리에 실릴 값 설정.
+         * inject 호출자 기준 — 자기 현재 spanId를 넣는다.
+         */
+        public Builder parentSpanId(long parentSpanId) {
+            this.parentSpanId = parentSpanId;
+            return this;
+        }
+
+        /**
+         * tracestate 벤더 영역에 키-값을 추가한다.
+         * key/value 중 하나라도 null이면 무시 (방어적 처리).
+         */
+        public Builder putTraceState(String key, String value) {
+            if (key != null && value != null) {
+                this.traceState.put(key, value);
+            }
+            return this;
+        }
+
+        /**
+         * baggage에 키-값을 추가한다.
+         * key/value 중 하나라도 null이면 무시.
+         */
+        public Builder putBaggage(String key, String value) {
+            if (key != null && value != null) {
+                this.baggage.put(key, value);
+            }
+            return this;
+        }
+
+        /**
+         * 불변 인스턴스 생성. 빌더의 내부 맵은 복사본 + unmodifiable 래핑되어,
+         * 빌더 재사용/수정이 결과 객체에 영향을 주지 않는다.
+         */
+        public PropagationContext build() {
+            return new PropagationContext(
+                    traceId,
+                    parentSpanId,
+                    Collections.unmodifiableMap(new LinkedHashMap<>(traceState)),
+                    Collections.unmodifiableMap(new LinkedHashMap<>(baggage)));
+        }
+    }
+}

--- a/agent-core/src/main/java/com/seeker/agent/core/context/propagation/PropagatorHolder.java
+++ b/agent-core/src/main/java/com/seeker/agent/core/context/propagation/PropagatorHolder.java
@@ -1,0 +1,53 @@
+package com.seeker.agent.core.context.propagation;
+
+/**
+ * 전역에서 {@link TraceContextPropagator}에 접근하기 위한 Holder.
+ *
+ * <p>왜 정적 holder인가?
+ * <ul>
+ *   <li>인터셉터는 ByteBuddy로 주입되어 일반 DI 컨테이너 바깥에서 동작한다 — 생성자 주입이 어렵다.</li>
+ *   <li>부트스트랩 시 1회만 등록되고 런타임 내내 재사용된다 — 정적 필드가 가장 단순하고 빠르다.</li>
+ * </ul>
+ *
+ * <p>사용 흐름:
+ * <ol>
+ *   <li>{@code AgentMain.premain()}에서 {@link #setPropagator(TraceContextPropagator)} 1회 호출</li>
+ *   <li>인터셉터에서 {@link #get()}으로 꺼내 inject/extract 호출</li>
+ * </ol>
+ *
+ * <p>{@code TraceContextHolder}, {@code AgentInfoHolder}와 같은 패턴.
+ *
+ * <p>기본값으로 {@link W3CTraceContextPropagator} 인스턴스를 갖고 있어서, 부트스트랩이 누락되어도
+ * 인터셉터가 NPE를 일으키지 않고 W3C 동작을 한다 — 안전한 자기충족 기본값.
+ */
+public final class PropagatorHolder {
+
+    /**
+     * volatile로 멀티 스레드 가시성 보장.
+     * 부트스트랩 시점 이후로는 거의 read-only이지만, 테스트에서 stub 주입 가능성을 위해 mutable로 둔다.
+     */
+    private static volatile TraceContextPropagator propagator = new W3CTraceContextPropagator();
+
+    /** 인스턴스화 차단 — 정적 유틸리티. */
+    private PropagatorHolder() {
+    }
+
+    /**
+     * 전역 propagator를 등록한다.
+     * 일반적으로 {@code AgentMain.premain()}에서 1회만 호출된다.
+     *
+     * @param p 새 propagator. {@code null}이면 무시(기존 값 유지) — 안전한 기본값을 보존하기 위함.
+     */
+    public static void setPropagator(TraceContextPropagator p) {
+        if (p != null) {
+            propagator = p;
+        }
+    }
+
+    /**
+     * 전역 propagator를 반환한다. 부트스트랩이 누락된 경우에도 기본 W3C 인스턴스가 반환되므로 null이 아니다.
+     */
+    public static TraceContextPropagator get() {
+        return propagator;
+    }
+}

--- a/agent-core/src/main/java/com/seeker/agent/core/context/propagation/TraceContextPropagator.java
+++ b/agent-core/src/main/java/com/seeker/agent/core/context/propagation/TraceContextPropagator.java
@@ -1,0 +1,47 @@
+package com.seeker.agent.core.context.propagation;
+
+/**
+ * 추적 컨텍스트를 헤더로 직렬화(inject)/역직렬화(extract)하는 정책 인터페이스.
+ *
+ * <p>이 인터페이스의 의의는 <strong>전파 포맷의 추상화</strong>이다.
+ * 새로운 포맷(W3C Trace Context, B3, Jaeger uber-trace-id 등)을 지원해야 할 때, 구현체만 추가하면 된다.
+ * 인터셉터·plugin 등 호출부 코드는 시그니처가 같으므로 영향받지 않는다.
+ *
+ * <p>호출은 {@link PropagatorHolder#get()}을 통해 전역 인스턴스를 꺼내 쓰는 것이 일반적이다.
+ *
+ * <p>구현 시 주의:
+ * <ul>
+ *   <li>인터셉터의 hot path에서 호출되므로 가능한 한 가볍게 동작해야 한다.</li>
+ *   <li>입력 헤더가 깨져 있어도 절대 throw 하지 않는다 — 인터셉터의 예외는 비즈니스 로직을 깨뜨릴 수 있다.
+ *       복원 실패 시 {@link PropagationContext#empty()}를 반환한다.</li>
+ *   <li>스레드-세이프해야 한다 (멀티 스레드 요청 처리 환경).</li>
+ * </ul>
+ */
+public interface TraceContextPropagator {
+
+    /**
+     * 현재 추적 컨텍스트를 캐리어의 헤더로 기록한다.
+     *
+     * <p>호출자(sender)는 자기 trace의 현재 상태를 {@code context}에 담아 전달한다.
+     * W3C 모델에서는 wire의 spanId 자리에 호출자의 현재 spanId가 실린다 — 다음 hop은 그 값을 자기 parentSpanId로 사용한다.
+     *
+     * @param context 보낼 추적 컨텍스트 (호출자의 현재 상태)
+     * @param carrier 헤더 운반체 (HttpRequest 등)
+     * @param setter  캐리어에 헤더를 기록할 수단 (라이브러리별 어댑터)
+     * @param <C>     캐리어 타입
+     */
+    <C> void inject(PropagationContext context, C carrier, HeaderSetter<C> setter);
+
+    /**
+     * 캐리어의 헤더에서 추적 컨텍스트를 복원한다.
+     *
+     * <p>수신자는 반환된 {@code PropagationContext.parentSpanId}를 자기 입장에서의 parentSpanId로 사용하고,
+     * 자기 spanId는 로컬에서 새로 생성한다(W3C self-generation 모델).
+     *
+     * @param carrier 헤더 운반체 (HttpServletRequest 등)
+     * @param getter  캐리어에서 헤더를 읽을 수단 (라이브러리별 어댑터)
+     * @param <C>     캐리어 타입
+     * @return 복원된 컨텍스트. 헤더가 없거나 파싱 실패 시 {@link PropagationContext#empty()} (null 반환하지 않음)
+     */
+    <C> PropagationContext extract(C carrier, HeaderGetter<C> getter);
+}

--- a/agent-core/src/main/java/com/seeker/agent/core/context/propagation/W3CTraceContextPropagator.java
+++ b/agent-core/src/main/java/com/seeker/agent/core/context/propagation/W3CTraceContextPropagator.java
@@ -1,0 +1,379 @@
+package com.seeker.agent.core.context.propagation;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * W3C Trace Context (https://www.w3.org/TR/trace-context/) 기반 propagator 구현체.
+ *
+ * <p>3개 헤더를 다룬다.
+ * <ul>
+ *   <li>{@code traceparent} : {@code 00-{traceId}-{spanId}-{flags}} 고정 포맷.
+ *       이때 spanId 자리는 <em>호출자의 현재 spanId</em>이며, 수신자에게는 자기 입장의 parentSpanId가 된다.</li>
+ *   <li>{@code tracestate}  : {@code seeker=k1:v1;k2:v2,vendor2=...} — 벤더 전용 키-값(예: {@code pAgentId})</li>
+ *   <li>{@code baggage}     : {@code k1=v1,k2=v2} — 애플리케이션 컨텍스트</li>
+ * </ul>
+ *
+ * <p>수신자는 {@code traceparent}의 spanId를 자기 parentSpanId로 사용하고, 자기 spanId는 로컬에서 새로 생성한다
+ * — 이른바 W3C self-generation 모델. sender 측 pre-allocation 구조가 아님.
+ *
+ * <p>동작 원칙:
+ * <ul>
+ *   <li>실패해도 throw 하지 않는다 — 인터셉터의 예외는 비즈니스 로직을 깨뜨릴 수 있으므로 항상 안전 반환.</li>
+ *   <li>스레드-세이프 — 모든 메서드가 인스턴스 상태를 변경하지 않음 (불변).</li>
+ * </ul>
+ */
+public class W3CTraceContextPropagator implements TraceContextPropagator {
+
+    // ===== W3C Trace Context 표준 헤더 이름 =====
+
+    public static final String TRACEPARENT = "traceparent";
+    public static final String TRACESTATE = "tracestate";
+    public static final String BAGGAGE = "baggage";
+
+    /**
+     * tracestate 안에서 우리 벤더 영역을 식별하는 키.
+     * 형태: {@code seeker=key:value;...} — 다른 벤더(예: {@code dd=...}, {@code nr=...})와 공존 가능.
+     */
+    public static final String VENDOR_KEY = "seeker";
+
+    /**
+     * traceparent 포맷 버전. 현재 표준은 {@code "00"}. 향후 표준이 바뀌면 새 버전 핸들링 필요.
+     */
+    private static final String VERSION = "00";
+
+    /**
+     * trace-flags 값.
+     * <ul>
+     *   <li>{@code "00"}: not sampled (수집되지 않음)</li>
+     *   <li>{@code "01"}: sampled (수집됨)</li>
+     * </ul>
+     * 현재는 항상 sampled로 고정. 추후 샘플링 정책이 들어오면 이 값을 동적으로 설정해야 한다.
+     */
+    private static final String SAMPLED_FLAGS = "01";
+
+    // ============================================================
+    // inject — 현재 컨텍스트를 헤더로 직렬화
+    // ============================================================
+
+    @Override
+    public <C> void inject(PropagationContext context, C carrier, HeaderSetter<C> setter) {
+        // 방어적 null/empty 체크 — 호출부 실수로 NPE가 비즈니스 코드까지 전파되지 않도록.
+        if (context == null || context.isEmpty() || carrier == null || setter == null) {
+            return;
+        }
+        String traceId = context.getTraceId();
+        if (traceId == null) {
+            return;
+        }
+
+        // 1) traceparent: 항상 발신
+        setter.setHeader(carrier, TRACEPARENT, formatTraceparent(traceId, context.getParentSpanId()));
+
+        // 2) tracestate: 벤더 메타데이터가 있을 때만 발신 (빈 헤더 보내지 않음)
+        String tracestate = formatTracestate(context.getTraceState());
+        if (tracestate != null) {
+            setter.setHeader(carrier, TRACESTATE, tracestate);
+        }
+
+        // 3) baggage: 애플리케이션 컨텍스트가 있을 때만 발신
+        if (!context.getBaggage().isEmpty()) {
+            setter.setHeader(carrier, BAGGAGE, formatBaggage(context.getBaggage()));
+        }
+    }
+
+    // ============================================================
+    // extract — 헤더에서 컨텍스트 복원
+    // ============================================================
+
+    @Override
+    public <C> PropagationContext extract(C carrier, HeaderGetter<C> getter) {
+        if (carrier == null || getter == null) {
+            return PropagationContext.empty();
+        }
+
+        // 1) traceparent 필수 — 없으면 추적 컨텍스트 없음으로 판단
+        String traceparent = getter.getHeader(carrier, TRACEPARENT);
+        if (traceparent == null || traceparent.isEmpty()) {
+            return PropagationContext.empty();
+        }
+
+        // 2) traceparent 파싱. 길이/숫자 검증 실패 시 empty 반환 (헤더 손상 방어)
+        ParsedTraceparent parsed = parseTraceparent(traceparent);
+        if (parsed == null) {
+            return PropagationContext.empty();
+        }
+
+        // 3) 빌더에 traceId + parentSpanId 채움.
+        //    wire의 spanId가 곧 수신자 입장의 parentSpanId.
+        PropagationContext.Builder builder = PropagationContext.builder()
+                .traceId(parsed.traceId)
+                .parentSpanId(parsed.spanId);
+
+        // 4) tracestate 파싱 (선택적) — seeker= 키 영역만 가져온다.
+        Map<String, String> tracestateMap = parseTracestate(getter.getHeader(carrier, TRACESTATE));
+        for (Map.Entry<String, String> e : tracestateMap.entrySet()) {
+            builder.putTraceState(e.getKey(), e.getValue());
+        }
+
+        // 5) baggage 파싱 (선택적)
+        Map<String, String> baggage = parseBaggage(getter.getHeader(carrier, BAGGAGE));
+        for (Map.Entry<String, String> e : baggage.entrySet()) {
+            builder.putBaggage(e.getKey(), e.getValue());
+        }
+
+        return builder.build();
+    }
+
+    // ============================================================
+    // traceparent 직렬화 / 파싱
+    // ============================================================
+
+    /**
+     * traceparent 헤더 값 문자열 생성.
+     * 결과 예: {@code 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01}
+     */
+    private static String formatTraceparent(String traceId, long spanId) {
+        return VERSION + "-"
+                + normalizeTraceId(traceId) + "-"   // 32-char hex 보장
+                + toSpanIdHex(spanId) + "-"         // long → 16-char hex
+                + SAMPLED_FLAGS;
+    }
+
+    /**
+     * traceparent 문자열을 (traceId, spanId)로 파싱.
+     *
+     * <p>표준 검증:
+     * <ul>
+     *   <li>4개 부분(version-traceId-spanId-flags)이 있어야 함</li>
+     *   <li>traceId는 정확히 32-char hex</li>
+     *   <li>spanId는 정확히 16-char hex</li>
+     * </ul>
+     *
+     * @return 파싱된 결과. 형식 위반 시 {@code null} (호출자가 empty로 처리)
+     */
+    private static ParsedTraceparent parseTraceparent(String traceparent) {
+        // 표준에 맞게 트림 후 split.
+        String[] parts = traceparent.trim().split("-");
+        if (parts.length < 4) {
+            // version만 미래에 늘어나도 (parts >= 4) 인 경우는 받아들임. 너무 짧으면 손상으로 판단.
+            return null;
+        }
+        String traceIdHex = parts[1];
+        String spanIdHex = parts[2];
+        // 길이 검증 — W3C 표준은 정확히 이 길이를 요구한다.
+        if (traceIdHex.length() != 32 || spanIdHex.length() != 16) {
+            return null;
+        }
+        try {
+            // unsigned 파싱: hex가 0x80...이상이면 long의 부호 비트가 1로 되어
+            // signed parseLong은 NumberFormatException을 던지기 때문.
+            long spanId = Long.parseUnsignedLong(spanIdHex, 16);
+            return new ParsedTraceparent(traceIdHex, spanId);
+        } catch (NumberFormatException e) {
+            // hex가 아닌 문자가 섞여 있는 경우 등.
+            return null;
+        }
+    }
+
+    /**
+     * traceId를 32-char lowercase hex로 정규화.
+     *
+     * <p>주된 용도는 inject 직전 안전망. 본 에이전트의 {@code TraceId}는 항상 32-char hex를 생성하므로
+     * 정상 경로에서는 입력이 이미 맞는 길이이다. 하지만 다음 케이스에서 안전망 역할:
+     * <ul>
+     *   <li>레거시 UUID 포맷이 외부에서 들어오는 경우 (구버전 에이전트 등)</li>
+     *   <li>테스트에서 짧은 문자열을 임의로 넣는 경우</li>
+     * </ul>
+     *
+     * <p>처리 규칙:
+     * <ul>
+     *   <li>32자 → 그대로</li>
+     *   <li>32자보다 길면 → 뒤쪽 32자 사용</li>
+     *   <li>32자보다 짧으면 → 앞에 0으로 패딩</li>
+     *   <li>null → 모두 0인 32자</li>
+     * </ul>
+     */
+    private static String normalizeTraceId(String traceId) {
+        if (traceId == null) {
+            return "00000000000000000000000000000000";
+        }
+        // UUID 포맷("xxxxxxxx-xxxx-...")의 하이픈 제거 + 소문자 통일.
+        String hex = traceId.replace("-", "").toLowerCase();
+        if (hex.length() == 32) {
+            return hex;
+        }
+        if (hex.length() > 32) {
+            // 더 긴 ID가 들어오면 뒷부분을 사용 (앞부분 손실보다 뒤가 보통 더 분산성이 좋음)
+            return hex.substring(hex.length() - 32);
+        }
+        // 짧으면 leading zero 패딩.
+        StringBuilder sb = new StringBuilder(32);
+        for (int i = hex.length(); i < 32; i++) {
+            sb.append('0');
+        }
+        sb.append(hex);
+        return sb.toString();
+    }
+
+    /**
+     * long spanId를 16-char lowercase hex로 변환.
+     * {@code %016x} : 16자리 폭, 부호 없는 hex, 부족하면 0 패딩.
+     */
+    private static String toSpanIdHex(long spanId) {
+        return String.format("%016x", spanId);
+    }
+
+    // ============================================================
+    // tracestate 직렬화 / 파싱
+    // ============================================================
+
+    /**
+     * vendor 영역 키-값 맵을 tracestate 헤더 값으로 직렬화.
+     *
+     * <p>출력 예: {@code seeker=pAgentId:agent01;pAppName:order-service}
+     *
+     * <p>구분자 선택:
+     * <ul>
+     *   <li>엔트리(벤더 간) 구분: {@code ,} (W3C 표준)</li>
+     *   <li>벤더 내부 키-값 페어 구분: {@code ;} (콤마는 표준 구분자라 사용 불가)</li>
+     *   <li>키-값 사이: {@code :}</li>
+     * </ul>
+     *
+     * @return tracestate 헤더 값. vendorEntries가 비어있으면 {@code null} (헤더 자체를 보내지 않음)
+     */
+    private static String formatTracestate(Map<String, String> vendorEntries) {
+        if (vendorEntries == null || vendorEntries.isEmpty()) {
+            return null;
+        }
+        StringBuilder vendorValue = new StringBuilder();
+        boolean first = true;
+        for (Map.Entry<String, String> e : vendorEntries.entrySet()) {
+            if (!first) {
+                vendorValue.append(';');  // 두 번째 이후 엔트리부터 구분자 추가
+            }
+            first = false;
+            vendorValue.append(sanitizeKey(e.getKey()))
+                    .append(':')
+                    .append(sanitizeValue(e.getValue()));
+        }
+        // "seeker=" 접두로 우리 벤더 영역임을 명시.
+        return VENDOR_KEY + "=" + vendorValue;
+    }
+
+    /**
+     * tracestate 헤더 값을 파싱하여 우리 벤더 영역의 키-값 맵을 추출.
+     *
+     * <p>다른 벤더 영역(예: {@code dd=...}, {@code nr=...})은 무시한다 — 우리 코드가 해석할 의무 없음.
+     * 다만 inject 시점에 패스스루 하려면 별도 보존이 필요할 수 있는데, 현재는 단순화를 위해 미구현.
+     */
+    private static Map<String, String> parseTracestate(String tracestate) {
+        Map<String, String> result = new LinkedHashMap<>();
+        if (tracestate == null || tracestate.isEmpty()) {
+            return result;
+        }
+        // 콤마로 벤더 엔트리 분리. 예: "seeker=...,dd=...,vendor2=..."
+        for (String entry : tracestate.split(",")) {
+            int eq = entry.indexOf('=');
+            if (eq <= 0) {
+                continue;  // "=" 없거나 키가 비어있으면 손상 — 건너뜀
+            }
+            String key = entry.substring(0, eq).trim();
+            String value = entry.substring(eq + 1).trim();
+            // 우리 벤더 영역만 처리. 그 외는 무시.
+            if (!VENDOR_KEY.equals(key)) {
+                continue;
+            }
+            // 벤더 내부의 키-값 페어 분해. 세미콜론으로 split, 콜론으로 키-값 분리.
+            for (String pair : value.split(";")) {
+                int colon = pair.indexOf(':');
+                if (colon <= 0) {
+                    continue;
+                }
+                result.put(pair.substring(0, colon).trim(), pair.substring(colon + 1).trim());
+            }
+        }
+        return result;
+    }
+
+    // ============================================================
+    // baggage 직렬화 / 파싱
+    // ============================================================
+
+    /**
+     * baggage 키-값 맵을 헤더 값으로 직렬화.
+     * 출력 예: {@code userId=alice,tenantId=acme}
+     *
+     * <p>tracestate와 달리 baggage는 벤더 키 없이 평면적인 key=value 리스트.
+     */
+    private static String formatBaggage(Map<String, String> baggage) {
+        StringBuilder sb = new StringBuilder();
+        boolean first = true;
+        for (Map.Entry<String, String> e : baggage.entrySet()) {
+            if (!first) {
+                sb.append(',');
+            }
+            first = false;
+            sb.append(sanitizeKey(e.getKey())).append('=').append(sanitizeValue(e.getValue()));
+        }
+        return sb.toString();
+    }
+
+    /**
+     * baggage 헤더를 파싱하여 키-값 맵으로 반환.
+     */
+    private static Map<String, String> parseBaggage(String baggage) {
+        Map<String, String> result = new LinkedHashMap<>();
+        if (baggage == null || baggage.isEmpty()) {
+            return result;
+        }
+        for (String entry : baggage.split(",")) {
+            int eq = entry.indexOf('=');
+            if (eq <= 0) {
+                continue;
+            }
+            result.put(entry.substring(0, eq).trim(), entry.substring(eq + 1).trim());
+        }
+        return result;
+    }
+
+    // ============================================================
+    // sanitization — 헤더 구분자 충돌 방지
+    // ============================================================
+
+    /**
+     * 키에서 W3C 헤더의 구분자/공백을 {@code _}로 치환.
+     * 키에 콤마/세미콜론/등호/콜론/공백이 들어가면 파싱이 깨지므로 미리 정리.
+     */
+    private static String sanitizeKey(String s) {
+        return s.replaceAll("[,;=:\\s]", "_");
+    }
+
+    /**
+     * 값에서 헤더 구분자(콤마/세미콜론/콜론)를 {@code _}로 치환.
+     * 값은 키와 달리 등호/공백은 허용해도 무방하므로 더 적은 문자만 치환.
+     */
+    private static String sanitizeValue(String s) {
+        return s.replaceAll("[,;:]", "_");
+    }
+
+    // ============================================================
+    // 내부 자료구조
+    // ============================================================
+
+    /**
+     * traceparent 파싱 결과를 묶기 위한 내부 값 객체.
+     * 메서드 두 개의 반환값을 묶어 전달하는 용도 — 외부 노출 안 함.
+     */
+    private static final class ParsedTraceparent {
+        /** 32-char hex traceId */
+        final String traceId;
+        /** wire의 spanId 자리 = 수신자에게는 parentSpanId */
+        final long spanId;
+
+        ParsedTraceparent(String traceId, long spanId) {
+            this.traceId = traceId;
+            this.spanId = spanId;
+        }
+    }
+}

--- a/agent-core/src/main/java/com/seeker/agent/core/model/AgentInfoHolder.java
+++ b/agent-core/src/main/java/com/seeker/agent/core/model/AgentInfoHolder.java
@@ -1,0 +1,23 @@
+package com.seeker.agent.core.model;
+
+/**
+ * 현재 에이전트의 {@link AgentInfo}를 전역에서 조회할 수 있게 해주는 Holder.
+ *
+ * 부트스트랩 시 1회 등록되며, 인터셉터(HTTP 클라이언트 등)가 자기 자신의 agentId를
+ * 분산 추적 헤더에 실어보낼 때 사용된다. (TraceContextHolder, PropagatorHolder와 동일 패턴)
+ */
+public final class AgentInfoHolder {
+
+    private static volatile AgentInfo agentInfo;
+
+    private AgentInfoHolder() {
+    }
+
+    public static void set(AgentInfo info) {
+        agentInfo = info;
+    }
+
+    public static AgentInfo get() {
+        return agentInfo;
+    }
+}

--- a/agent-core/src/main/java/com/seeker/agent/core/model/Span.java
+++ b/agent-core/src/main/java/com/seeker/agent/core/model/Span.java
@@ -14,7 +14,7 @@ public class Span {
     private int elapsedTime;
     private final String remoteAddr;
     private String agentId;
-    private String applicationName;
+    private String parentAgentId;
     private String uri;
     private String endPoint;
     private int serviceType;
@@ -70,12 +70,12 @@ public class Span {
         this.agentId = agentId;
     }
 
-    public String getApplicationName() {
-        return applicationName;
+    public String getParentAgentId() {
+        return parentAgentId;
     }
 
-    public void setApplicationName(String applicationName) {
-        this.applicationName = applicationName;
+    public void setParentAgentId(String parentAgentId) {
+        this.parentAgentId = parentAgentId;
     }
 
     public String getUri() {

--- a/agent-core/src/test/java/com/seeker/agent/core/context/ThreadLocalTraceContextTest.java
+++ b/agent-core/src/test/java/com/seeker/agent/core/context/ThreadLocalTraceContextTest.java
@@ -30,13 +30,18 @@ class ThreadLocalTraceContextTest {
     }
 
     @Test
-    @DisplayName("전달받은 TraceId를 사용하여 트레이스를 이어간다")
+    @DisplayName("전달받은 traceId/parentSpanId 위에 자기 spanId는 새로 생성하여 트레이스를 이어간다")
     void continueTraceObject() {
-        TraceId parentId = new TraceId();
-        Trace trace = threadLocalTraceContext.newTraceObject(parentId);
+        String parentTraceId = "0123456789abcdef0123456789abcdef";
+        long parentSpanId = 0xdeadbeefL;
+
+        Trace trace = threadLocalTraceContext.continueTraceObject(parentTraceId, parentSpanId);
 
         assertNotNull(trace);
-        assertEquals(parentId, trace.getTraceId());
+        assertEquals(parentTraceId, trace.getTraceId().getTraceId());
+        assertEquals(parentSpanId, trace.getTraceId().getParentSpanId());
+        // 자기 spanId는 로컬 생성 — parentSpanId와 절대 같지 않아야 한다.
+        assertNotEquals(parentSpanId, trace.getTraceId().getSpanId());
         assertEquals(trace, threadLocalTraceContext.currentTraceObject());
 
         threadLocalTraceContext.removeTraceObject();

--- a/agent-sender/src/main/java/com/seeker/agent/sender/ConsoleSpanTransport.java
+++ b/agent-sender/src/main/java/com/seeker/agent/sender/ConsoleSpanTransport.java
@@ -29,7 +29,6 @@ public class ConsoleSpanTransport implements SpanTransport {
         sb.append("Span{")
                 .append("traceId=").append(span.getTraceId())
                 .append(", agentId=").append(span.getAgentId())
-                .append(", applicationName=").append(span.getApplicationName())
                 .append(", uri=").append(span.getUri())
                 .append(", endPoint=").append(span.getEndPoint())
                 .append(", serviceType=").append(span.getServiceType())

--- a/agent-sender/src/main/java/com/seeker/agent/sender/GrpcDataMessageConverter.java
+++ b/agent-sender/src/main/java/com/seeker/agent/sender/GrpcDataMessageConverter.java
@@ -31,8 +31,8 @@ public class GrpcDataMessageConverter {
                 .setUri(span.getUri() != null ? span.getUri() : "")
                 .setEndPoint(span.getEndPoint() != null ? span.getEndPoint() : "")
                 .setServiceType(span.getServiceType())
-                .setApplicationName(applicationName)
-                .setAgentId(agentId);
+                .setAgentId(agentId)
+                .setParentAgentId(span.getParentAgentId() != null ? span.getParentAgentId() : "");
 
         if (span.getExceptionInfo() != null) {
             spanBuilder.setExceptionInfo(span.getExceptionInfo());

--- a/agent-sender/src/main/proto/seeker.proto
+++ b/agent-sender/src/main/proto/seeker.proto
@@ -62,15 +62,15 @@ message TraceId {
 message Span {
   TraceId trace_id = 1;
   string agent_id = 2;
-  string application_name = 3;
-  int64 start_time = 4;              // Span 시작 시간 (Epoch Millis)
-  int32 elapsed_time = 5;            // 소요 시간 (Millis)
-  string uri = 6;                    // 요청된 RPC / URL 통계용
-  string remote_addr = 7;            // 호출자(클라이언트) IP
-  string end_point = 8;              // 리소스 엔드포인트
-  int32 service_type = 9;            // TOMCAT, SPRING_BOOT 등 서비스 타입 코드
-  string exception_info = 10;        // 발생한 Exception 내역 (없으면 빈 문자열)
-  repeated SpanEvent span_event_list = 11; // 내부의 상세 이벤트들
+  int64 start_time = 3;              // Span 시작 시간 (Epoch Millis)
+  int32 elapsed_time = 4;            // 소요 시간 (Millis)
+  string uri = 5;                    // 요청된 RPC / URL 통계용
+  string remote_addr = 6;            // 호출자(클라이언트) IP
+  string end_point = 7;              // 리소스 엔드포인트
+  int32 service_type = 8;            // TOMCAT, SPRING_BOOT 등 서비스 타입 코드
+  string exception_info = 9;        // 발생한 Exception 내역 (없으면 빈 문자열)
+  repeated SpanEvent span_event_list = 10; // 내부의 상세 이벤트들
+  string parent_agent_id = 11;       // 본 요청을 보낸 상위 호출자 에이전트의 ID (루트일 경우 빈 문자열)
 }
 
 // Span 내부에서 발생한 세부 작업 단위 (DB 쿼리, 외부 HTTP 호출 등)

--- a/plugins/httpclient-plugin/src/main/java/com/seeker/agent/plugin/http/HttpClientExecuteInterceptor.java
+++ b/plugins/httpclient-plugin/src/main/java/com/seeker/agent/plugin/http/HttpClientExecuteInterceptor.java
@@ -3,16 +3,24 @@ package com.seeker.agent.plugin.http;
 import com.seeker.agent.core.context.TraceContext;
 import com.seeker.agent.core.context.TraceContextHolder;
 import com.seeker.agent.core.context.TraceId;
+import com.seeker.agent.core.context.propagation.PropagationContext;
+import com.seeker.agent.core.context.propagation.PropagatorHolder;
+import com.seeker.agent.core.model.AgentInfo;
+import com.seeker.agent.core.model.AgentInfoHolder;
 import com.seeker.agent.core.model.MethodType;
 import com.seeker.agent.core.model.SpanEvent;
 import com.seeker.agent.core.model.Trace;
 import com.seeker.agent.instrument.interceptor.AroundInterceptor;
+import com.seeker.agent.plugin.http.adapter.ApacheHttpRequestSetter;
 import org.apache.http.HttpRequest;
 import org.apache.http.RequestLine;
 
 /**
  * Apache HttpClient 4.x의 InternalHttpClient.doExecute 메서드를 가로채는 인터셉터입니다.
- * 외부 서비스 호출 시 트레이스 컨텍스트를 전파(Propagation)하는 역할을 합니다.
+ * 외부 서비스 호출 시 W3C Trace Context를 헤더로 전파(Propagation)하는 역할을 합니다.
+ *
+ * <p>현재 trace의 spanId를 그대로 wire에 실어 보낸다. 다음 hop은 이 값을 자기 parentSpanId로 받고
+ * 자기 spanId는 자체 생성한다.
  */
 public class HttpClientExecuteInterceptor implements AroundInterceptor {
 
@@ -32,40 +40,39 @@ public class HttpClientExecuteInterceptor implements AroundInterceptor {
                 event.setMethodType(MethodType.HTTP_CLIENT.getCode());
             }
 
-            // Distributed Tracing: Inject headers into HttpRequest (args[1])
+            // Distributed Tracing: W3C 헤더 inject — 현재 spanId를 그대로 송출
             if (args != null && args.length > 1 && args[1] instanceof HttpRequest) {
                 HttpRequest request = (HttpRequest) args[1];
-                TraceId nextId = trace.getTraceId().getNextTraceId();
+                TraceId current = trace.getTraceId();
 
-                request.addHeader("Seeker-Context", nextId.encode());
+                PropagationContext.Builder ctxBuilder = PropagationContext.builder()
+                        .traceId(current.getTraceId())
+                        .parentSpanId(current.getSpanId());
+
+                AgentInfo myInfo = AgentInfoHolder.get();
+                if (myInfo != null && myInfo.getAgentId() != null) {
+                    ctxBuilder.putTraceState("pAgentId", myInfo.getAgentId());
+                }
+                PropagatorHolder.get().inject(ctxBuilder.build(), request, ApacheHttpRequestSetter.INSTANCE);
 
                 // URL과 Method를 캡쳐하여 Attribute 추가
                 RequestLine requestLine = request.getRequestLine();
-                if (requestLine != null) {
-                    String uri = requestLine.getUri();
-                    String httpMethod = requestLine.getMethod();
-
-                    if (event != null) {
-                        event.addAttribute("http.url", uri);
-                        event.addAttribute("http.method", httpMethod);
-                        // 다음 서버로 전파되는 Span ID 기록
-                        event.addAttribute("nextSpanId", String.valueOf(nextId.getSpanId()));
-                    }
+                if (requestLine != null && event != null) {
+                    event.addAttribute("http.url", requestLine.getUri());
+                    event.addAttribute("http.method", requestLine.getMethod());
                 }
             }
 
             // HttpHost(args[0]) 정보를 통해 목적지 식별
             if (args != null && args.length > 0 && args[0] != null && event != null) {
-                // org.apache.http.HttpHost 인스턴스인지 체크 (방어적 코드)
                 Object hostObj = args[0];
                 if (hostObj.getClass().getName().contains("HttpHost")) {
                     event.addAttribute("destinationId", hostObj.toString());
                 } else {
-                    // HttpHost가 아닐 경우 URL에서 추출 시도
-                    RequestLine requestLine = (args.length > 1 && args[1] instanceof HttpRequest) 
-                            ? ((HttpRequest)args[1]).getRequestLine() : null;
+                    RequestLine requestLine = (args.length > 1 && args[1] instanceof HttpRequest)
+                            ? ((HttpRequest) args[1]).getRequestLine() : null;
                     if (requestLine != null) {
-                         event.addAttribute("destinationId", requestLine.getUri());
+                        event.addAttribute("destinationId", requestLine.getUri());
                     }
                 }
             }

--- a/plugins/httpclient-plugin/src/main/java/com/seeker/agent/plugin/http/adapter/ApacheHttpRequestSetter.java
+++ b/plugins/httpclient-plugin/src/main/java/com/seeker/agent/plugin/http/adapter/ApacheHttpRequestSetter.java
@@ -1,0 +1,25 @@
+package com.seeker.agent.plugin.http.adapter;
+
+import com.seeker.agent.core.context.propagation.HeaderSetter;
+import org.apache.http.HttpRequest;
+
+/**
+ * Apache HttpComponents의 {@link HttpRequest}에 헤더를 기록하는 어댑터.
+ */
+public final class ApacheHttpRequestSetter implements HeaderSetter<HttpRequest> {
+
+    public static final ApacheHttpRequestSetter INSTANCE = new ApacheHttpRequestSetter();
+
+    private ApacheHttpRequestSetter() {
+    }
+
+    @Override
+    public void setHeader(HttpRequest carrier, String name, String value) {
+        if (carrier == null || name == null || value == null) {
+            return;
+        }
+        // 동일 헤더 중복 방지: 기존 헤더가 있으면 교체.
+        carrier.removeHeaders(name);
+        carrier.addHeader(name, value);
+    }
+}

--- a/plugins/tomcat-plugin/src/main/java/com/seeker/agent/plugin/was/tomcat/StandardHostValveInvokeInterceptor.java
+++ b/plugins/tomcat-plugin/src/main/java/com/seeker/agent/plugin/was/tomcat/StandardHostValveInvokeInterceptor.java
@@ -2,15 +2,20 @@ package com.seeker.agent.plugin.was.tomcat;
 
 import com.seeker.agent.core.context.TraceContext;
 import com.seeker.agent.core.context.TraceContextHolder;
-import com.seeker.agent.core.context.TraceId;
+import com.seeker.agent.core.context.propagation.PropagationContext;
+import com.seeker.agent.core.context.propagation.PropagatorHolder;
 import com.seeker.agent.core.model.ServiceType;
 import com.seeker.agent.core.model.Span;
 import com.seeker.agent.core.model.Trace;
 import com.seeker.agent.instrument.interceptor.AroundInterceptor;
+import com.seeker.agent.plugin.was.tomcat.adapter.HttpServletRequestGetter;
 import org.apache.catalina.connector.Request;
 
 /**
  * Tomcat StandardHostValve.invoke 메서드를 가로채서 웹 요청의 시작과 끝을 추적하는 인터셉터입니다.
+ *
+ * <p>W3C Trace Context를 받아 trace에 합류한다. wire의 spanId를 자기 parentSpanId로 사용하고,
+ * 자기 spanId는 {@link TraceContext#continueTraceObject(String, long)} 안에서 새로 생성된다.
  */
 public class StandardHostValveInvokeInterceptor implements AroundInterceptor {
 
@@ -20,23 +25,27 @@ public class StandardHostValveInvokeInterceptor implements AroundInterceptor {
 
         TraceContext context = TraceContextHolder.getContext();
 
-        // 분산 트레이싱: 요청 헤더에서 컨텍스트 추출
-        TraceId tid = null;
-
+        // 분산 트레이싱: 요청 헤더에서 wire 컨텍스트 추출 (W3C Trace Context)
+        PropagationContext propagated = PropagationContext.empty();
+        String parentAgentId = null;
+        Request request = null;
         if (args != null && args.length > 0 && args[0] instanceof Request) {
-            Request request = (Request) args[0];
-            String encodedContext = request.getHeader("Seeker-Context");
-            tid = TraceId.decode(encodedContext);
+            request = (Request) args[0];
+            propagated = PropagatorHolder.get()
+                    .extract(request, HttpServletRequestGetter.INSTANCE);
+            if (!propagated.isEmpty()) {
+                parentAgentId = propagated.getTraceState().get("pAgentId");
+            }
         }
 
         if (context.currentTraceObject() == null) {
             Trace trace;
-            if (tid != null) {
-                // 기존 트레이스 이어받기
-                trace = context.newTraceObject(tid);
+            if (!propagated.isEmpty()) {
+                // 받은 traceId/parentSpanId 위에 자기 spanId를 새로 생성하여 합류
+                trace = context.continueTraceObject(propagated.getTraceId(), propagated.getParentSpanId());
                 System.out.println("[Seeker] 기존 Trace 이어받음: " + trace.getTraceId());
             } else {
-                // 새로운 트레이스 시작
+                // 새로운 루트 트레이스 시작
                 trace = context.newTraceObject();
                 System.out.println("[Seeker] 새로운 Trace 시작: " + trace.getTraceId());
             }
@@ -45,8 +54,11 @@ public class StandardHostValveInvokeInterceptor implements AroundInterceptor {
             Span span = trace.getSpan();
             // 서비스 타입을 TOMCAT으로 설정
             span.setServiceType(ServiceType.TOMCAT.getCode());
-            if (args != null && args.length > 0 && args[0] instanceof Request) {
-                Request request = (Request) args[0];
+            if (parentAgentId != null && !parentAgentId.isEmpty()) {
+                span.setParentAgentId(parentAgentId);
+                System.out.println("[Seeker] Parent Agent: " + parentAgentId);
+            }
+            if (request != null) {
                 // 요청 URI 및 엔드포인트 정보 설정
                 span.setUri(request.getRequestURI());
                 span.setEndPoint(request.getLocalAddr() + ":" + request.getLocalPort());

--- a/plugins/tomcat-plugin/src/main/java/com/seeker/agent/plugin/was/tomcat/adapter/HttpServletRequestGetter.java
+++ b/plugins/tomcat-plugin/src/main/java/com/seeker/agent/plugin/was/tomcat/adapter/HttpServletRequestGetter.java
@@ -1,0 +1,24 @@
+package com.seeker.agent.plugin.was.tomcat.adapter;
+
+import com.seeker.agent.core.context.propagation.HeaderGetter;
+import org.apache.catalina.connector.Request;
+
+/**
+ * Tomcat의 {@link Request}로부터 헤더를 읽어오는 어댑터.
+ * propagator의 라이브러리 의존성을 plugin 모듈로 분리하는 역할.
+ */
+public final class HttpServletRequestGetter implements HeaderGetter<Request> {
+
+    public static final HttpServletRequestGetter INSTANCE = new HttpServletRequestGetter();
+
+    private HttpServletRequestGetter() {
+    }
+
+    @Override
+    public String getHeader(Request carrier, String name) {
+        if (carrier == null || name == null) {
+            return null;
+        }
+        return carrier.getHeader(name);
+    }
+}


### PR DESCRIPTION
Resolves : #6

## ✨ 작업 개요

# 분산 추적 헤더 전파(Propagation) 도입

> 자체 CSV 기반 헤더(`Seeker-Context`)를 W3C Trace Context 표준(`traceparent` / `tracestate` / `baggage`)으로 교체하고, 새 포맷·라이브러리 추가에 열려 있도록 모듈 경계를 정리한 작업 기록.

---

## 1. 왜 이 작업을 했는가 (배경 / 동기)

### 1.1 기존 구조의 한계

기존에는 `TraceId`가 직접 헤더 직렬화 책임까지 가지고 있었다.

```java
// (이전) TraceId.java
public String encode() {
    return traceId + "," + spanId + "," + parentSpanId;
}
public static TraceId decode(String encoded) { ... }
```

그리고 인터셉터에서 자체 헤더 이름(`Seeker-Context`)으로 이 CSV를 직접 주고받았다.

```java
// (이전) HttpClientExecuteInterceptor
request.addHeader("Seeker-Context", nextId.encode());

// (이전) StandardHostValveInvokeInterceptor
String encodedContext = request.getHeader("Seeker-Context");
tid = TraceId.decode(encodedContext);
```

이 구조는 다음 3가지 문제가 있었다.

1. **OpenTelemetry / 다른 언어와 trace가 끊긴다.** 자체 헤더는 OTel SDK가 모르고, OTel SDK가 보내는 `traceparent`는 우리 에이전트가 모른다. 하이브리드 APM(자체 Java 에이전트 + 다른 언어는 OTel SDK + 프록시는 OTel native)을 지향한다면 표준 호환은 필수.
2. **확장 축이 한 모듈에 묶여 있다.** 헤더 포맷을 바꾸려면 `TraceId`를, 운반체(Tomcat / OkHttp / gRPC)를 늘리려면 인터셉터를 같이 손대야 했다. 두 축의 변경 비용이 곱해진다.
3. **`TraceId`의 책임 과적재.** 값 객체(식별자 묶음)면서 인코딩/디코딩 로직까지 들고 있어, 새 포맷 추가가 곧 `TraceId` 수정이 되어버린다.

### 1.2 목표

- W3C Trace Context를 1차 포맷으로 채택해 OTel 생태계와 호환.
- 헤더 포맷(W3C / B3 / Jaeger …)과 운반체(Tomcat / OkHttp / gRPC …)를 **독립적으로 추가** 가능하게.
- `TraceId`는 순수 값 객체로 정리.
- agentId / appName 같은 벤더 메타데이터는 `tracestate`에, userId 같은 비즈니스 컨텍스트는 `baggage`에 실을 수 있도록 자료구조 마련.

---

## 2. 설계 개요

### 2.1 책임 3분할

| 레이어 | 라이브러리 의존성 | 위치 |
|---|---|---|
| **L1. 전파 정책** (W3C 포맷 파싱/생성) | 없음 (순수 로직) | `agent-core/context/propagation/` |
| **L2. 캐리어 어댑터** (HttpServletRequest 등) | 라이브러리별 | 각 `plugins/<lib>-plugin/.../adapter/` |
| **L3. 인터셉터** (extract/inject 호출) | 라이브러리별 | 각 plugin의 인터셉터 |

핵심은 **L1을 plugin 안에 넣지 않는다**는 점이다. 그러면 plugin 간 의존이 생기고 L1이 라이브러리에 묶여버린다. L1은 모든 plugin이 공유하는 공통 정책이므로 `agent-core`에 둔다.

### 2.2 인터페이스 4개 + 값 객체 1개 (OTel `TextMapPropagator` 패턴 차용)

```
agent-core/context/propagation/
├── HeaderGetter<C>            # 캐리어에서 헤더 읽기
├── HeaderSetter<C>            # 캐리어에 헤더 쓰기
├── PropagationContext         # traceId + tracestate + baggage 값 객체
├── TraceContextPropagator     # inject / extract
├── W3CTraceContextPropagator  # 구현체
└── PropagatorHolder           # 전역 접근점 (TraceContextHolder와 같은 패턴)
```

캐리어는 `<C>` 제네릭으로 추상화해서, propagator 한 본체를 모든 plugin이 재사용한다. 새 라이브러리는 `HeaderGetter`/`HeaderSetter`만 구현하면 된다.

### 2.3 데이터 흐름 (W3C self-generation 방식)

핵심 의미: **wire의 spanId 자리는 호출자(A)의 spanId이며, 수신자(B)에게는 자기 입장에서의 parentSpanId가 된다.** B의 spanId는 B가 로컬에서 새로 생성한다 (sender 측 pre-allocation 없음).

```
[A: HTTP client plugin — inject]
    Trace.getTraceId() = (T, Sa, Pa)            # Pa = A의 parent. 헤더에 안 보냄.
              │
              ▼
    PropagationContext( traceId=T, parentSpanId=Sa, traceState={pAgentId:A} )
              │
              ▼  propagator.inject(ctx, request, ApacheHttpRequestSetter)
              ▼
    traceparent: 00-T-Sa-01                     # ← Sa: A의 현재 spanId
    tracestate : seeker=pAgentId:A
    baggage    : k=v,...

[B: Tomcat plugin — extract]
    Request ──▶ propagator.extract(...)
              │
              ▼
    PropagationContext( traceId=T, parentSpanId=Sa, traceState={pAgentId:A} )
              │
              ▼  context.continueTraceObject(T, Sa)
              ▼
    Trace.getTraceId() = (T, Sb_local, Sa)      # ← Sb_local: B가 새로 생성
                                                # ← Sa: B의 parentSpanId
```

`tracestate`에서 `ps:` 키는 더 이상 사용하지 않는다. wire의 spanId 자리(traceparent)가 곧 parent의 의미를 가지므로 별도 필드가 불필요하다.

### 2.4 W3C ↔ seeker 모델 매핑

| seeker 모델 (local) | W3C 표현 (wire) | 비고 |
|---|---|---|
| `TraceId.traceId` (32-char hex) | `traceparent`의 trace-id 부분 | UUID(36자)에서 16바이트 hex(32자)로 변경 |
| `TraceId.spanId` (long) | inject 시 `traceparent`의 parent-id 자리 / extract 시에는 의미 없음(로컬 생성) | 내부 long 유지(gRPC proto 호환), 직렬화 시에만 16-char hex |
| `TraceId.parentSpanId` (long) | extract 시 `traceparent`의 parent-id 자리에서 채움 / inject 시에는 의미 없음 | wire는 항상 호출자의 현재 spanId만 운반 |
| **`Span.parentAgentId`** (String) | **`tracestate`에 `seeker=pAgentId:<id>`** | 호출자 에이전트의 식별자 |
| 벤더 메타데이터(appName 등) | `tracestate`에 `seeker=key:value;...` | 향후 확장 |
| 비즈니스 컨텍스트(userId 등) | `baggage`에 `key=value,...` | 향후 확장 |

표를 한 줄로 요약: **wire에는 항상 호출자의 spanId만 흐른다. 자기 spanId는 항상 로컬에서 새로 만든다.**

### 2.5 parentAgentId 전파 흐름

서비스 A → 서비스 B 호출 시 B가 "누가 나를 호출했는지"를 알 수 있도록 A의 agentId를 헤더에 실어 보낸다.

```
[A의 HttpClient 인터셉터: inject]
    AgentInfoHolder.get().getAgentId()  ──▶  PropagationContext.traceState["pAgentId"] = <A.agentId>
                                              │
                                              ▼
                              tracestate: seeker=pAgentId:<A.agentId>
                                              │
                                              ▼
[B의 Tomcat 인터셉터: extract]
    PropagationContext.traceState.get("pAgentId")  ──▶  Span.parentAgentId = <A.agentId>
                                                          │
                                                          ▼
                                          gRPC 전송 시 proto Span.parent_agent_id 채워서 collector로
```

핵심 포인트: A의 자기 agentId는 부트스트랩 시 `AgentInfoHolder`에 등록되어 인터셉터에서 정적 접근으로 꺼내 쓴다(인터셉터는 ByteBuddy 주입이라 일반 DI 불가).

`spanId`/`parentSpanId`를 long 그대로 두는 이유는 `agent-sender/GrpcDataMessageConverter`가 `setSpanId(long)`/`setParentSpanId(long)`을 호출하기 때문이다. proto 인터페이스를 건드리지 않기 위한 절충.

---

## 3. 추가 / 수정된 파일

### 3.1 신규 파일

| 경로 | 역할 |
|---|---|
| `agent-core/.../context/propagation/HeaderGetter.java` | 캐리어 → 헤더 읽기 추상화 |
| `agent-core/.../context/propagation/HeaderSetter.java` | 캐리어 ← 헤더 쓰기 추상화 |
| `agent-core/.../context/propagation/PropagationContext.java` | wire 표현 값 객체 (traceId + tracestate + baggage) |
| `agent-core/.../context/propagation/TraceContextPropagator.java` | inject / extract 인터페이스 |
| `agent-core/.../context/propagation/W3CTraceContextPropagator.java` | W3C 구현체 |
| `agent-core/.../context/propagation/PropagatorHolder.java` | propagator 전역 접근점 (volatile, 기본값 W3C) |
| `agent-core/.../model/AgentInfoHolder.java` | AgentInfo 전역 접근점 (인터셉터에서 자기 agentId 조회) |
| `plugins/tomcat-plugin/.../adapter/HttpServletRequestGetter.java` | Tomcat `Request` ↔ `HeaderGetter` 어댑터 |
| `plugins/httpclient-plugin/.../adapter/ApacheHttpRequestSetter.java` | Apache `HttpRequest` ↔ `HeaderSetter` 어댑터 |
| `docs/propagation.md` | 본 문서 |

### 3.2 수정된 파일

| 경로 | 변경 요지 |
|---|---|
| `agent-core/.../context/TraceId.java` | UUID 기반 traceId → 16바이트 hex(32자) 생성. **`getNextTraceId()` 제거** (sender pre-allocation 불필요), 대신 **`continueWith(traceId, parentSpanId)` 정적 팩토리 추가** (자기 spanId는 로컬 생성). `encode/decode/from()` 제거 (책임을 W3CPropagator로 이전) — 순수 값 객체. |
| `agent-core/.../context/TraceContext.java` | **`newTraceObject(TraceId)` 제거**, **`continueTraceObject(String traceId, long parentSpanId)` 추가**. 의도가 메서드 이름에 드러남(루트 시작 vs 기존 trace 합류). |
| `agent-core/.../context/ThreadLocalTraceContext.java` | 인터페이스 변경에 맞춰 구현 갱신 |
| `agent-core/.../context/propagation/PropagationContext.java` | wire 표현으로 정렬: **`TraceId` 필드 제거**, `traceId(String)` + `parentSpanId(long)` 기본 필드. wire와 local 자료구조 분리. |
| `agent-core/.../context/propagation/W3CTraceContextPropagator.java` | **`tracestate`의 `ps:` 키 emit/parse 제거**. extract 시 `traceparent`의 spanId를 곧장 `PropagationContext.parentSpanId`로 매핑. inject는 호출자가 넘긴 `parentSpanId`(=호출자의 현재 spanId)를 traceparent에 기록. |
| `agent-core/.../model/Span.java` | `parentAgentId` 필드 + getter/setter 추가 |
| `agent-core/src/test/.../ThreadLocalTraceContextTest.java` | `continueTraceObject` 테스트로 갱신, 자기 spanId가 받은 parentSpanId와 다른 값으로 새로 생성되는지 검증 |
| `agent-sender/.../proto/seeker.proto` | `Span.parent_agent_id` 필드 추가 |
| `agent-sender/.../GrpcDataMessageConverter.java` | `Span.parentAgentId → proto parent_agent_id` 매핑 추가 |
| `plugins/tomcat-plugin/.../StandardHostValveInvokeInterceptor.java` | extract 후 `context.continueTraceObject(traceId, parentSpanId)` 호출(자기 spanId 자체생성). tracestate의 `pAgentId` 키를 `Span.parentAgentId`에 기록. |
| `plugins/httpclient-plugin/.../HttpClientExecuteInterceptor.java` | **`getNextTraceId` 호출 제거**. 현재 trace의 `(traceId, spanId)`를 그대로 wire에 inject. `AgentInfoHolder`에서 자기 agentId를 읽어 tracestate에 `pAgentId:<id>`로 inject. SpanEvent의 `nextSpanId` 속성 제거(개념 사라짐). |
| `agent-bootstrap/.../AgentMain.java` | `PropagatorHolder.setPropagator(new W3CTraceContextPropagator())` + `AgentInfoHolder.set(agentInfo)` 등록 |

---

## 4. 컴포넌트별 설계 의도

### 4.1 `HeaderGetter<C>` / `HeaderSetter<C>` — 캐리어 추상화

```java
public interface HeaderGetter<C> { String getHeader(C carrier, String name); }
public interface HeaderSetter<C> { void   setHeader(C carrier, String name, String value); }
```

- **왜 제네릭으로?** Tomcat의 `Request`, Apache의 `HttpRequest`, OkHttp의 `Request`, gRPC의 `Metadata`를 한 propagator가 다루려면 운반체 타입을 약식 추상화해야 한다.
- **왜 `agent-core`에?** 인터페이스 자체는 라이브러리 의존이 없다. 구현(어댑터)만 plugin에 둔다. 이렇게 해야 plugin 간 의존이 생기지 않는다.
- **OTel과의 정합:** OTel `io.opentelemetry.context.propagation.TextMapGetter/Setter`의 단순화 버전이다. 나중에 OTel SDK로 갈아끼울 때도 사고 흐름이 동일.

### 4.2 `PropagationContext` — wire 표현 값 객체

local의 `TraceId`(traceId+spanId+parentSpanId 묶음)와 wire는 의미가 다르므로 **별도 자료구조**로 분리했다. wire는 호출자의 spanId만 운반하면 충분하다.

```java
final String traceId;        // 32-char hex, 공유
final long parentSpanId;     // wire의 spanId 자리 = 수신자의 parentSpanId
final Map<String, String> traceState;
final Map<String, String> baggage;
```

- **왜 `TraceId`를 안 들고 `String + long`?** wire는 호출자의 (traceId, spanId)만 있으면 된다. 수신자는 자기 spanId를 로컬에서 새로 만들기 때문에 wire에 그게 실릴 필요가 없다. `TraceId`(local 값)를 wire 객체가 들고 있으면 의미가 섞여서 "이 spanId가 누구 거지?"가 헷갈려진다.
- **이름이 `parentSpanId`인 이유.** wire의 spanId 자리는 inject/extract 양쪽에서 의미가 다르다(inject는 자기 현재 spanId, extract는 자기 parentSpanId). 두 의미 중 **수신자 입장**을 채택해 `parentSpanId`로 명명했다 — extract 결과를 그대로 사용하기 직관적이고, inject 호출자는 "내 현재 spanId가 다음 hop의 parent" 라는 멘탈 모델 한 번만 잡으면 된다.
- **왜 빌더?** 호출부가 traceId/parentSpanId만 채울 수도, tracestate·baggage까지 채울 수도 있다. 향후 필드 확장 시 호환성 유지가 쉽다.
- **왜 immutable?** 헤더가 인터셉터 사이를 오갈 때 의도치 않은 mutation 차단.
- **왜 `EMPTY` 싱글톤?** extract 실패 시 null 대신 `isEmpty()`로 통일 — 호출부의 null 체크 강제 해소.

### 4.3 `TraceContextPropagator` — 정책 인터페이스

```java
<C> void               inject(PropagationContext ctx, C carrier, HeaderSetter<C> setter);
<C> PropagationContext extract(C carrier, HeaderGetter<C> getter);
```

이 두 메서드가 전파 정책의 전부다. 새 포맷(B3, Jaeger)을 추가해도 시그니처는 그대로, 구현체만 추가된다.

### 4.4 `W3CTraceContextPropagator` — W3C 구현

핵심 결정사항:

- **`traceparent` 포맷:** `00-{32hexTraceId}-{16hexSpanId}-01`. 버전(00)·flags(01=sampled) 고정. spanId 자리는 항상 호출자의 spanId.
- **자기 spanId 자체 생성:** sender는 자기 현재 spanId를 그대로 보내고, receiver는 받은 spanId를 자기 parentSpanId로만 쓴다 — 자기 spanId는 `TraceContext.continueTraceObject` 안에서 새로 만든다. 그래서 `tracestate`에 별도 parentSpanId 운반 키(`ps`)가 **불필요**하며 제거됨.
- **벤더 영역 직렬화:** `seeker=k1:v1;k2:v2` (콤마는 W3C tracestate의 엔트리 구분자라 사용 불가, 세미콜론으로 키-값 페어 구분).
- **방어적 처리:** 길이 검증 후 `Long.parseUnsignedLong`. 실패 시 `PropagationContext.empty()` 반환 — 인입 헤더가 깨져 있어도 절대 throw 하지 않는다(인터셉터 예외가 비즈니스 로직을 건드리면 안 되므로).
- **`normalizeTraceId`:** 기존 UUID 포맷 데이터가 흘러올 가능성을 고려해, 32자가 아닌 입력을 32자로 패딩/잘라내는 안전망. 시간이 지나 더 이상 필요 없어지면 삭제.

### 4.5 `PropagatorHolder` — 전역 접근점

기존 `TraceContextHolder`와 같은 패턴(JVM 전역 단일 인스턴스). 다음 두 가지 이유로 채택:

- **인터셉터에서 DI 불가:** ByteBuddy로 주입되는 인터셉터는 일반적인 의존성 주입 컨테이너 바깥에 있다. 정적 holder가 가장 단순하다.
- **부트스트랩 시점에 1회 등록:** `volatile` 필드로 가시성 보장. 런타임 교체 가능성도 열어 둠(테스트에서 stub 주입 등).

기본값으로 `W3CTraceContextPropagator`를 두어, 부트스트랩이 누락되어도 인터셉터가 NPE를 일으키지 않게 한다.

### 4.6 어댑터들 — plugin 안에 두는 이유

`HttpServletRequestGetter`는 Tomcat의 `org.apache.catalina.connector.Request`에 직접 의존한다. 이 의존을 `agent-core`로 끌어오면:

- `agent-core`가 Tomcat에 의존하는 순환적 결과 → core 모듈의 의미 파괴
- 다른 WAS(Jetty, Undertow) plugin을 추가할 때 core를 또 건드려야 함

따라서 어댑터는 의존하는 라이브러리와 **같은 plugin** 안에 둔다. 이렇게 하면:

- Jetty plugin 추가 → `JettyRequestGetter`만 plugin 안에 작성, `agent-core` / 다른 plugin은 그대로
- OkHttp plugin 추가 → `OkHttpRequestSetter`만 작성

`INSTANCE` 싱글톤 패턴은 stateless라 인스턴스를 재사용하기 위함(인터셉터의 hot path).

### 4.7 `TraceId` — 순수 값 객체

식별자 묶음만 들고 있는 값 객체. 헤더 직렬화는 W3CPropagator, 자기 spanId 새로 만들기는 `continueWith` 정적 팩토리로 분리.

```java
// root 시작
TraceId root = new TraceId();

// 외부 trace에 합류 (자기 spanId는 안에서 새로 생성)
TraceId joined = TraceId.continueWith(receivedTraceId, receivedParentSpanId);
```

`getNextTraceId()`(과거의 sender pre-allocation용)는 제거됨. 자기 spanId를 미리 생성해 wire에 실어 보내는 모델이 사라졌기 때문에 dead code였다.

`traceId`를 UUID String → 16바이트 hex로 바꾼 이유는 W3C 호환. `spanId`/`parentSpanId`는 gRPC proto가 long을 요구하므로 그대로 유지.

### 4.8 `TraceContext` — 의도가 메서드 이름에 드러나도록

```java
Trace newTraceObject();                                   // 루트 시작
Trace continueTraceObject(String traceId, long parentSpanId);  // 기존 trace 합류
```

이전 시그니처(`newTraceObject(TraceId)`)는 호출부가 자기 spanId를 미리 할당해서 넘겼는지, 아니면 단순히 traceId만 잇는지 구분이 안 됐다. **메서드 두 개로 분리**해서 호출부 한 줄만 봐도 의도가 드러나도록 했다. `continueTraceObject` 구현은 받은 (traceId, parentSpanId)에 자기 spanId 새로 부여하는 책임이 응집되어 있다.

---

## 5. 인터셉터 변경 비교

### 5.1 inject (HttpClientExecuteInterceptor)

**Before** (Pinpoint식 sender pre-allocation)
```java
TraceId nextId = trace.getTraceId().getNextTraceId();   // 다음 hop의 spanId 미리 생성
request.addHeader("Seeker-Context", nextId.encode());
```

**After** (W3C self-generation, 호출자는 자기 상태만 송출)
```java
TraceId current = trace.getTraceId();
PropagationContext outgoing = PropagationContext.builder()
        .traceId(current.getTraceId())
        .parentSpanId(current.getSpanId())              // 내 현재 spanId가 다음 hop의 parent
        .putTraceState("pAgentId", agentInfo.getAgentId())
        .build();
PropagatorHolder.get().inject(outgoing, request, ApacheHttpRequestSetter.INSTANCE);
```

→ 헤더 이름·포맷·자료구조 + **next id 사전할당까지** 인터셉터에서 사라졌다. 인터셉터는 이제 "내 현재 trace 상태를 보낸다"만 안다.

### 5.2 extract (StandardHostValveInvokeInterceptor)

**Before**
```java
String encodedContext = request.getHeader("Seeker-Context");
tid = TraceId.decode(encodedContext);
trace = context.newTraceObject(tid);                    // sender가 만든 spanId를 그대로 사용
```

**After**
```java
PropagationContext propagated = PropagatorHolder.get()
        .extract(request, HttpServletRequestGetter.INSTANCE);
if (!propagated.isEmpty()) {
    trace = context.continueTraceObject(
        propagated.getTraceId(),
        propagated.getParentSpanId());                  // 자기 spanId는 안에서 새로 생성
}
```

→ 헤더 파싱 지식 + **수신 측 spanId 자체 생성**도 인터셉터에서 사라졌다. `continueTraceObject` 한 호출이 모든 책임을 흡수.

---

## 6. 확장 시나리오 (이 설계가 유효한지 검증)

### 6.1 Jetty plugin 추가 시

1. `plugins/jetty-plugin/.../adapter/JettyRequestGetter.java` 작성 (10줄)
2. Jetty 인터셉터에서 `propagator.extract(request, JettyRequestGetter.INSTANCE)` 호출
3. `agent-core`, `tomcat-plugin`, `httpclient-plugin` 변경 없음

### 6.2 B3 (Zipkin) 포맷 동시 지원

1. `agent-core/.../propagation/B3Propagator.java` 작성
2. `CompositePropagator`(추후 추가)에서 W3C + B3 체이닝
3. plugin 변경 없음

### 6.3 agentId / appName을 헤더에 싣고 싶을 때

`agentId`(키 `pAgentId`)는 이미 적용되어 있다(§2.5 참조). `appName` 추가는 인터셉터에서 한 줄로 끝난다.

```java
PropagationContext.Builder ctxBuilder = PropagationContext.builder()
        .traceId(current.getTraceId())
        .parentSpanId(current.getSpanId());
AgentInfo myInfo = AgentInfoHolder.get();
if (myInfo != null) {
    ctxBuilder.putTraceState("pAgentId", myInfo.getAgentId());
    ctxBuilder.putTraceState("pAppName", myInfo.getAgentName());  // ← 한 줄 추가
}
```

받는 쪽에서는 `propagated.getTraceState().get("pAppName")`으로 꺼내 `Span.parentApplicationName`(필드는 추가 필요)에 기록한다.

### 6.4 OTel SDK로 단계적 마이그레이션

`TraceContextPropagator` 인터페이스 시그니처가 OTel `TextMapPropagator`와 의미적으로 같다. 어댑터 한 장으로 OTel SDK의 propagator를 우리 인터페이스에 끼워 넣을 수 있다.

---


