### PR TITLE
[FEAT] HTTP status code를 Tomcat span / HttpClient span event에 기록

### DIFF
--- a/agent-core/src/main/java/com/seeker/agent/core/model/Span.java
+++ b/agent-core/src/main/java/com/seeker/agent/core/model/Span.java
@@ -18,6 +18,7 @@ public class Span {
     private String uri;
     private String endPoint;
     private int serviceType;
+    private int statusCode;
     private String exceptionInfo;
     private final List<SpanEvent> spanEventList = new ArrayList<>();
 
@@ -100,6 +101,14 @@ public class Span {
 
     public void setServiceType(int serviceType) {
         this.serviceType = serviceType;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    public void setStatusCode(int statusCode) {
+        this.statusCode = statusCode;
     }
 
     public String getExceptionInfo() {

--- a/agent-sender/src/main/java/com/seeker/agent/sender/GrpcDataMessageConverter.java
+++ b/agent-sender/src/main/java/com/seeker/agent/sender/GrpcDataMessageConverter.java
@@ -32,7 +32,8 @@ public class GrpcDataMessageConverter {
                 .setEndPoint(span.getEndPoint() != null ? span.getEndPoint() : "")
                 .setServiceType(span.getServiceType())
                 .setAgentId(agentId)
-                .setParentAgentId(span.getParentAgentId() != null ? span.getParentAgentId() : "");
+                .setParentAgentId(span.getParentAgentId() != null ? span.getParentAgentId() : "")
+                .setStatusCode(span.getStatusCode());
 
         if (span.getExceptionInfo() != null) {
             spanBuilder.setExceptionInfo(span.getExceptionInfo());

--- a/agent-sender/src/main/proto/seeker.proto
+++ b/agent-sender/src/main/proto/seeker.proto
@@ -71,6 +71,7 @@ message Span {
   string exception_info = 9;        // 발생한 Exception 내역 (없으면 빈 문자열)
   repeated SpanEvent span_event_list = 10; // 내부의 상세 이벤트들
   string parent_agent_id = 11;       // 본 요청을 보낸 상위 호출자 에이전트의 ID (루트일 경우 빈 문자열)
+  int32 status_code = 12;            // HTTP 응답 상태 코드 (0이면 미설정)
 }
 
 // Span 내부에서 발생한 세부 작업 단위 (DB 쿼리, 외부 HTTP 호출 등)

--- a/plugins/httpclient-plugin/src/main/java/com/seeker/agent/plugin/http/HttpClientExecuteInterceptor.java
+++ b/plugins/httpclient-plugin/src/main/java/com/seeker/agent/plugin/http/HttpClientExecuteInterceptor.java
@@ -13,6 +13,7 @@ import com.seeker.agent.core.model.Trace;
 import com.seeker.agent.instrument.interceptor.AroundInterceptor;
 import com.seeker.agent.plugin.http.adapter.ApacheHttpRequestSetter;
 import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
 import org.apache.http.RequestLine;
 
 /**
@@ -86,6 +87,15 @@ public class HttpClientExecuteInterceptor implements AroundInterceptor {
         Trace trace = context.currentTraceObject();
 
         if (trace != null) {
+            // 응답 상태 코드를 attribute로 기록
+            SpanEvent event = trace.currentSpanEvent();
+            if (event != null && result instanceof HttpResponse) {
+                HttpResponse response = (HttpResponse) result;
+                if (response.getStatusLine() != null) {
+                    event.addAttribute("http.code",
+                            String.valueOf(response.getStatusLine().getStatusCode()));
+                }
+            }
             // 외부 호출 블록 종료 및 예외 정보 기록
             trace.traceBlockEnd(throwable);
             System.out.println("[Seeker] HTTP 외부 요청 완료: " + className + "." + methodName + " 종료");

--- a/plugins/tomcat-plugin/src/main/java/com/seeker/agent/plugin/was/tomcat/StandardHostValveInvokeInterceptor.java
+++ b/plugins/tomcat-plugin/src/main/java/com/seeker/agent/plugin/was/tomcat/StandardHostValveInvokeInterceptor.java
@@ -10,6 +10,7 @@ import com.seeker.agent.core.model.Trace;
 import com.seeker.agent.instrument.interceptor.AroundInterceptor;
 import com.seeker.agent.plugin.was.tomcat.adapter.HttpServletRequestGetter;
 import org.apache.catalina.connector.Request;
+import org.apache.catalina.connector.Response;
 
 /**
  * Tomcat StandardHostValve.invoke 메서드를 가로채서 웹 요청의 시작과 끝을 추적하는 인터셉터입니다.
@@ -73,6 +74,11 @@ public class StandardHostValveInvokeInterceptor implements AroundInterceptor {
         Trace trace = context.currentTraceObject();
 
         if (trace != null) {
+            // HTTP 응답 상태 코드 기록
+            if (args != null && args.length > 1 && args[1] instanceof Response) {
+                Response response = (Response) args[1];
+                trace.getSpan().setStatusCode(response.getStatus());
+            }
             // 전체 트레이스 종료 및 데이터 전송
             trace.finish();
             System.out.println("[Seeker] Tomcat 요청 처리 완료: " + trace.getTraceId() + " (elapsed: "


### PR DESCRIPTION
## ✨ 작업 개요

Tomcat에서 응답이 반환될 때의 HTTP 상태 코드를 root Span에 기록하고, Apache HttpClient로 외부 호출 시 응답의 상태 코드를 해당 SpanEvent의 attribute에 기록하도록 추가했습니다. gRPC 메시지 스키마에도 반영해 collector로 전송됩니다.

## 📝 변경 사항

- `Span` 모델에 `statusCode` 필드 + getter/setter 추가
- Tomcat 인터셉터(`StandardHostValveInvokeInterceptor.after()`)에서 `args[1]` Response의 `getStatus()`를 root span에 set
- `agent-sender/src/main/proto/seeker.proto`의 `Span` 메시지에 `int32 status_code = 12` 필드 추가
- `GrpcDataMessageConverter#toDataMessage`에서 `setStatusCode(span.getStatusCode())` 매핑 추가
- HttpClient 인터셉터(`HttpClientExecuteInterceptor.after()`)에서 응답값(`HttpResponse`)의 `getStatusLine().getStatusCode()`를 SpanEvent의 `http.code` attribute로 기록

## 🔗 관련 이슈

Closes #4

## ✅ 체크리스트

- [x] 로컬에서 빌드 및 테스트를 통과했습니다.
- [ ] 관련 문서를 업데이트했습니다. (필요한 경우)
- [x] 리뷰어가 확인하기 쉽도록 변경 사항을 정리했습니다.

## 💬 리뷰어에게

- proto3 forward-compat 덕분에 collector 측 미동기화 시에도 깨지지는 않지만, **collector 레포의 `seeker.proto`에도 `status_code = 12` 필드를 동일 번호로 추가하는 후속 작업이 필요**합니다.