### PR TITLE
Feat/#11/jvm metric agent

### DIFF
--- a/PINPOINT_ANALYSIS_AND_DESIGN.md
+++ b/PINPOINT_ANALYSIS_AND_DESIGN.md
@@ -1,0 +1,643 @@
+# Pinpoint 분석 → 자체 APM 에이전트 설계 노트
+
+본 문서는 Pinpoint 오픈소스(https://github.com/pinpoint-apm/pinpoint)의
+JVM 모니터링/메트릭 파이프라인을 코드 레벨로 분석하고, 그 결과를 우리
+`apm-agent` / `apm-collector` 프로젝트 설계에 어떻게 반영할지 정리한
+설계 노트입니다.
+
+분석 기준 코드: `C:/Users/SSAFY/seok/pinpoint`
+
+---
+
+## 0. 한눈에 보는 Pinpoint 메트릭 파이프라인
+
+```
+[Agent JVM]
+   ScheduledExecutor (1 daemon thread, 5s 주기)
+     └ AgentStatCollector.collect()      ← 12종 MXBean snapshot
+        └ N cycle 누적 후 batch flush
+           └ gRPC bidirectional stream (StatService.sendAgentStat)
+                                                │
+                                                ▼
+[Collector]
+   StatService          (PStatMessage receiver)
+     └ AgentMetricBatchHandler
+        └ GrpcAgentStatBatchMapper       proto → AgentStatBo
+           └ AgentStatGroupService       fan-out to backends
+              └ PinotAgentStatService.save()
+                 ├ validateTime(10분)    Pinot segment 보호
+                 ├ AgentStatModelConverter.convertXxx
+                 │     도메인 → EAV row (long-form)
+                 ├ DAO.insertAgentStat        → Kafka topic (hashed by app)
+                 └ DAO.insertApplicationStat  → Kafka topic (single)
+                                                │
+                                                ▼
+[Apache Pinot real-time]
+   agent_stat / application_stat 테이블 segment 적재
+                                                │
+                                                ▼
+[Web]
+   AgentInspectorStatController
+     └ TimeWindowSlotCentricSampler(10s, 200) 다운샘플링
+        └ PinotAgentStatDao (AVG / MAX / SUM SQL)
+           └ React 차트 (200 포인트 고정)
+```
+
+---
+
+## 1. 측정 대상 — Pinpoint가 모니터링하는 12종 JVM 리소스
+
+`AgentStatCollector` (`agent-module/profiler/.../monitor/collector/AgentStatCollector.java:86`)
+가 한 cycle에 호출하는 11+1개의 sub-collector:
+
+| # | Collector | 측정 항목 | 핵심 MXBean |
+|---|-----------|-----------|-------------|
+| 1 | BasicJvmGcMetricCollector | heap/non-heap used·max, GC old count·time, gcType | MemoryMXBean, GarbageCollectorMXBean |
+| 2 | DetailedJvmGcMetricCollector | Eden/Survivor/Old/CodeCache/Perm/Metaspace 사용률, GC new count·time | MemoryPoolMXBean × 6 |
+| 3 | DefaultCpuLoadMetric | jvm CPU load, system CPU load (0~1) | com.sun.management.OperatingSystemMXBean |
+| 4 | DefaultTransactionMetric | sampled new/continuation, unsampled, skipped (delta) | TransactionCounter (내부) |
+| 5 | DefaultActiveTraceMetricCollector | fast/normal/slow/very-slow 활성 트레이스 분포 | ActiveTraceHistogram (내부) |
+| 6 | DefaultDataSourceMetricCollector | pool별 active/max connection | 등록된 DataSourceMonitor |
+| 7 | DefaultResponseTimeMetric | 윈도우 avg, max | ResponseTimeCollector.resetAndGetValue |
+| 8 | DefaultDeadlockMetric | deadlock 스레드 ID set | DeadlockThreadLocator (별도 monitor 스레드) |
+| 9 | OracleFileDescriptorMetric | open file descriptor count | com.sun.management.UnixOperatingSystemMXBean |
+| 10 | DefaultBufferMetric | direct/mapped buffer count·memoryUsed | BufferPoolMXBean |
+| 11 | DefaultTotalThreadMetric | thread count | ThreadMXBean |
+| 12 | DefaultLoadedClassMetric | loaded class count, unloaded class count | ClassLoadingMXBean |
+
+### JMX로 추가 가능한 metric (Pinpoint가 안 쓰지만 우리는 검토 대상)
+
+- `MemoryMXBean.getObjectPendingFinalizationCount()` — finalizer 적체 감지
+- `ThreadMXBean.getPeakThreadCount()` / `getDaemonThreadCount()` — 스레드 leak 감지에 유용
+- `ThreadMXBean.getThreadCpuTime(id)` — 스레드별 CPU 핫스팟
+- `CompilationMXBean.getTotalCompilationTime()` — JIT 활동
+- `RuntimeMXBean.getUptime()` — 단순한데 dashboard용으로 자주 필요
+- `com.sun.management.OperatingSystemMXBean.getFreePhysicalMemorySize()` — 컨테이너 OOM 예측
+- `GarbageCollectionNotificationInfo` (push 모델) — 각 GC 이벤트의 cause/duration/before·after — pause time 분포 측정
+- `HotSpotDiagnosticMXBean.dumpHeap()` — on-demand heap dump
+
+JMX로 **불가능한 것**: GC pause 분포(이벤트 listener는 가능), allocation rate, lock contention 상세, async stack profiling, JIT inlining. 이건 JFR / JVMTI native agent / async-profiler 영역.
+
+---
+
+## 2. 에이전트 측 수집 로직 (Pinpoint 패턴)
+
+### 2-1. 스케줄러 — `DefaultAgentStatMonitor`
+
+`agent-module/profiler/.../monitor/DefaultAgentStatMonitor.java:51`
+
+```java
+private static final long MIN_COLLECTION_INTERVAL_MS = 1000;
+private static final long MAX_COLLECTION_INTERVAL_MS = 1000 * 10;
+
+private final ScheduledExecutorService executor =
+    new ScheduledThreadPoolExecutor(1,
+        new PinpointThreadFactory("Pinpoint-stat-monitor", true));  // daemon
+
+@Override
+public void start() {
+    executor.scheduleAtFixedRate(statMonitorJob,
+        this.collectionIntervalMs, this.collectionIntervalMs, TimeUnit.MILLISECONDS);
+}
+```
+
+핵심:
+- **단일 데몬 스레드** — 비즈니스 스레드와 격리.
+- 인터벌은 [1s, 10s]로 클램프, 기본 5s.
+- **pre-load class 트릭**: `start()` 전에 `EmptyDataSender`로 `CollectJob.run()`을 2번 미리 호출 → JDK 6 시절 classloader 순환 deadlock(#2881) 방지. 우리 프로젝트도 안전 보험으로 유지 권장.
+
+### 2-2. 한 cycle의 흐름 — `CollectJob`
+
+`agent-module/profiler/.../monitor/CollectJob.java:62`
+
+```java
+@Override
+public void run() {
+    final long currentCollectionTimestamp = System.currentTimeMillis();
+    final long collectInterval = currentCollectionTimestamp - this.prevCollectionTimestamp;
+    try {
+        final AgentStatMetricSnapshot agentStat = agentStatCollector.collect();
+        agentStat.setTimestamp(currentCollectionTimestamp);
+        agentStat.setCollectInterval(collectInterval);   // 측정된 wall-clock interval
+        this.agentStats.add(agentStat);
+        if (++this.collectCount >= numCollectionsPerBatch) {
+            sendAgentStats();
+            this.collectCount = 0;
+        }
+    } catch (Exception ex) {
+        logger.warn("AgentStat collect failed. Caused:{}", ex.getMessage(), ex);
+    } finally {
+        this.prevCollectionTimestamp = currentCollectionTimestamp;
+    }
+}
+
+private void sendAgentStats() {
+    final AgentStatMetricSnapshotBatch agentStatBatch = new AgentStatMetricSnapshotBatch();
+    agentStatBatch.setAgentId(agentId);
+    agentStatBatch.setStartTimestamp(agentStartTimestamp);
+    agentStatBatch.setAgentStats(this.agentStats);
+    this.agentStats = new ArrayList<>(numCollectionsPerBatch);  // list swap (lock-free)
+    dataSender.send(agentStatBatch);
+}
+```
+
+핵심 4가지:
+1. **`collectInterval`은 측정값**: 스케줄 인터벌(5초)이 아니라 실제 경과 시간. GC pause로 8초가 됐으면 8초로 보냄. → 컬렉터가 정확한 TPS 계산 가능.
+2. **N cycle 누적 후 batch flush** (default 6) → gRPC 호출 1/6로 절감.
+3. **list swap**: `sendAgentStats()`가 새 ArrayList를 할당하고 기존 리스트는 dataSender 스레드에 넘김 → lock 없이 producer/consumer 분리.
+4. **try-catch 격리**: 한 cycle 실패해도 throw 안 하고 다음 cycle 진행.
+
+### 2-3. MXBean 호출은 단순 polling
+
+대표 예시 (`agent-module/profiler/.../monitor/metric/memory/DefaultMemoryMetric.java:34`):
+
+```java
+@Override
+public MemoryMetricSnapshot getSnapshot() {
+    final MemoryUsage heapMemoryUsage = memoryMXBean.getHeapMemoryUsage();
+    final MemoryUsage nonHeapMemoryUsage = memoryMXBean.getNonHeapMemoryUsage();
+    return new MemoryMetricSnapshot(
+        heapMemoryUsage.getMax(),     heapMemoryUsage.getUsed(),
+        nonHeapMemoryUsage.getMax(),  nonHeapMemoryUsage.getUsed());
+}
+```
+
+DetailedMemory의 ratio 변환 (`DefaultDetailedMemoryMetric.java:78`):
+
+```java
+private double calculateUsage(MemoryUsage memoryUsage) {
+    if (memoryUsage == null) return UNCOLLECTED_USAGE;
+    long max = memoryUsage.getMax() == -1 ? memoryUsage.getCommitted() : memoryUsage.getMax();
+    if (max == -1 || max == 0) return UNCOLLECTED_USAGE;
+    return memoryUsage.getUsed() / (double) max;   // 0~1 비율
+}
+```
+
+→ ZGC/Metaspace처럼 `max == -1`(unbounded)인 pool을 `committed`로 fallback. 절댓값 byte가 아니라 **사용률(0~1)**로 보내서 차트 친화적.
+
+### 2-4. GC 알고리즘 자동 감지
+
+`agent-module/profiler/.../context/provider/stat/jvmgc/GarbageCollectorMetricProvider.java:46`
+
+```java
+@Override
+public GarbageCollectorMetric get() {
+    Map<String, GarbageCollectorMXBean> map = createGarbageCollectorMap();
+    for (GarbageCollectorType garbageCollectorType : GarbageCollectorType.values()) {
+        if (map.containsKey(garbageCollectorType.oldGenName())) {
+            return new DefaultGarbageCollectorMetric(garbageCollectorType,
+                map.get(garbageCollectorType.oldGenName()));
+        }
+    }
+    return new UnknownGarbageCollectorMetric();   // ← graceful fallback
+}
+```
+
+`GarbageCollectorType.java:23`:
+
+```java
+SERIAL  (JvmGcType.SERIAL,   "MarkSweepCompact",       "Copy"),
+PARALLEL(JvmGcType.PARALLEL, "PS MarkSweep",           "PS Scavenge"),
+CMS     (JvmGcType.CMS,      "ConcurrentMarkSweep",    "ParNew"),
+G1      (JvmGcType.G1,       "G1 Old Generation",      "G1 Young Generation"),
+ZGC     (JvmGcType.ZGC,      "ZGC Major Pauses",       "ZGC Minor Pauses");
+```
+
+`GarbageCollectorMXBean.getName()`을 보고 5종 GC 알고리즘 자동 매칭. 매칭 실패 시 `UnknownGarbageCollectorMetric`.
+
+### 2-5. 값의 종류별 처리 (snapshot vs delta vs window)
+
+| 종류 | Pinpoint 예시 | 처리 위치 |
+|------|--------------|-----------|
+| Gauge (snapshot) | heap used, threadCount, CPU, fd | 폴링값 그대로 |
+| Cumulative counter | GC count, GC time, classes loaded | agent 누적값 그대로 → 서버에서 차분 |
+| Delta gauge | transaction count | agent에서 prev 보관 (`TransactionGauge`) |
+| Window reset | response time avg/max | cycle마다 reset |
+
+`TransactionGauge` 구현 (`DefaultTransactionMetric.java:96`):
+
+```java
+private long getTransactionCount() {
+    final long transactionCount = longCounter.getCount();
+    if (transactionCount < 0) return UNCOLLECTED;
+    if (this.prevTransactionCount == UNINITIALIZED) {
+        this.prevTransactionCount = transactionCount;
+        return 0L;       // 첫 호출은 0 (spike 방지)
+    }
+    final long delta = transactionCount - this.prevTransactionCount;
+    this.prevTransactionCount = transactionCount;
+    return delta;
+}
+```
+
+### 2-6. graceful degradation (필수)
+
+`profiler-optional/.../DefaultCpuLoadMetric.java:44`:
+
+```java
+CpuUsageProvider jvmCpuUsageProvider = new JvmCpuUsageProvider(operatingSystemMXBean);
+try {
+    jvmCpuUsageProvider.getCpuUsage();
+} catch (NoSuchMethodError e) {
+    logger.warn("Expected method not found ...");
+    jvmCpuUsageProvider = CpuUsageProvider.UNSUPPORTED;
+}
+```
+
+→ JDK 메서드가 없으면 `UNSUPPORTED` provider로 교체. 메트릭 하나가 죽어도 다른 메트릭에 영향 없음.
+
+---
+
+## 3. 컬렉터 측 수신 로직 (참고용)
+
+### 3-1. gRPC bidirectional stream
+
+`collector/.../receiver/grpc/service/StatService.java:75`
+
+```java
+@Override
+public StreamObserver<PStatMessage> sendAgentStat(StreamObserver<Empty> responseStream) {
+    long streamId = serverStreamId.incrementAndGet();
+    UidFetcher fetcher = uidFetcherStreamService.newUidFetcher();
+    return new ServerCallStream<>(logger, streamId, fetcher, responseObserver,
+        this::onNext, streamCloseOnError, Empty::getDefaultInstance);
+}
+```
+
+요청-응답이 아니라 **에이전트가 한 번 stream 열고 stat을 push**. trace stream과 분리되어 한쪽이 폭주해도 다른 쪽이 영향 없음.
+
+### 3-2. 도메인 매핑 — Visitor 패턴
+
+`collector/.../mapper/grpc/stat/GrpcAgentStatMapper.java:59`
+
+```java
+void map(PAgentStat agentStat, AgentStatBo.Builder builder) {
+    final long timestamp = agentStat.getTimestamp();
+    AgentStatBo.Builder.StatBuilder statBuilder = builder.newStatBuilder(timestamp);
+    for (GrpcStatMapper mapper : mappers) {     // 12개 매퍼가 같은 builder 방문
+        mapper.map(statBuilder, agentStat);
+    }
+}
+```
+
+각 매퍼는 자기가 책임지는 stat만 추가 (`GrpcCpuLoadBoMapper.java:37`):
+
+```java
+@Override
+public void map(AgentStatBo.Builder.StatBuilder builder, PAgentStat agentStat) {
+    if (agentStat.hasCpuLoad()) {                // proto에 필드 있을 때만
+        DataPoint point = builder.getDataPoint();
+        builder.addPoint(this.map(point, agentStat.getCpuLoad()));
+    }
+}
+```
+
+→ 매퍼 추가/제거가 다른 매퍼에 영향 없음.
+
+### 3-3. EAV 변환 — 핵심 디자인
+
+`inspector-collector/.../model/kafka/AgentStatModelConverter.java:78` (JVM GC 1건 → 7 row):
+
+```java
+public List<AgentStat> convertJvmGc(List<JvmGcBo> boList, String tenantId) {
+    AgentStatList list = new AgentStatList(boList.size() * 7);
+    for (JvmGcBo jvmGcBo : boList) {
+        final AgentStatList.Collector builder = list.newCollect(tenantId, jvmGcBo);
+        builder.collect(AgentStatField.JVM_GC_TYPE,            jvmGcBo.getGcType().getTypeCode());
+        builder.collect(AgentStatField.JVM_GC_HEAP_USED,       jvmGcBo.getHeapUsed());
+        builder.collect(AgentStatField.JVM_GC_HEAP_MAX,        jvmGcBo.getHeapMax());
+        builder.collect(AgentStatField.JVM_GC_NONHEAP_USED,    jvmGcBo.getNonHeapUsed());
+        builder.collect(AgentStatField.JVM_GC_NONHEAP_MAX,     jvmGcBo.getNonHeapMax());
+        builder.collect(AgentStatField.JVM_GC_NONHEAP_GC_OLD_COUNT, jvmGcBo.getGcOldCount());
+        builder.collect(AgentStatField.JVM_GC_NONHEAP_GC_OLD_TIME,  jvmGcBo.getGcOldTime());
+    }
+    return list.build();
+}
+```
+
+`AgentStat` 객체 (`AgentStat.java:30`):
+
+```java
+public class AgentStat {
+    private final String tenantId;
+    private final long timestamp;
+    private final String applicationName;
+    private final String agentId;
+    private final String sortKey;
+    private final String metricName;       // 예: "JVM_GC"
+    private final String fieldName;        // 예: "JVM_GC_HEAP_USED"
+    private final double fieldValue;
+    private final List<Tag> tags;
+}
+```
+
+**EAV(Entity-Attribute-Value) 형태**: 12종 stat이 모두 같은 스키마를 공유 → 단일 Pinot 테이블에 적재, 새 metric 추가 시 스키마 변경 0.
+
+### 3-4. PinotMappers — Reflection 기반 매퍼 자동 등록
+
+`inspector-collector/.../service/PinotMappers.java:39`
+
+```java
+public List<PinotTypeMapper<StatDataPoint>> getMapper() {
+    List<Method> methods = findDeclaredMethods(this.getClass(), this::isTypeMapper);
+    List<PinotTypeMapper<StatDataPoint>> mappers = new ArrayList<>();
+    for (Method method : methods) {
+        logger.info("Found PinotTypeMapper : {}", method.getName());
+        mappers.add(newMapper(method));
+    }
+    return mappers;
+}
+
+private boolean isTypeMapper(Method method) {
+    return method.getName().startsWith("get") &&
+           PinotTypeMapper.class.isAssignableFrom(method.getReturnType());
+}
+
+public PinotTypeMapper<CpuLoadBo> getCpuLoad() {
+    return new PinotTypeMapper<>(AgentStatBo::getCpuLoadBos, agentMapper::convertCpuLoad);
+}
+```
+
+→ 새 metric 추가 = `getXxx()` 메서드 한 개 + `convertXxx` 한 개. **자동 등록**. 우리 라우터에도 그대로 적용 가능.
+
+### 3-5. 시간 검증 (Pinot segment 보호)
+
+`PinotAgentStatService.java:87`:
+
+```java
+private boolean validateTime(List<? extends StatDataPoint> agentStatData) {
+    Instant collectedTime = Instant.ofEpochMilli(point.getTimestamp());
+    Instant validTime = Instant.now().minus(Duration.ofMinutes(10));
+    if (!validTime.isBefore(collectedTime)) {
+        logger.info("AgentStat data is invalid. ...");
+        return false;
+    }
+    return true;
+}
+```
+
+→ 10분 이상 늦은 데이터는 **통째 drop**. real-time 시간 파티션 오염 방지. 클럭 스큐 방어를 겸함.
+
+---
+
+## 4. 자체 에이전트 설계 가이드
+
+### 4-1. 7가지 핵심 결정사항
+
+설계 진입 전에 이걸 먼저 못 박으세요:
+
+| # | 결정 | Pinpoint 선택 | 우리 권장 |
+|---|------|---------------|-----------|
+| 1 | Pull vs Push | Pull (단일 스레드 폴링) + GC notification은 push | 동일 |
+| 2 | 값의 종류 표시 | enum 없음 (서버가 metric 이름으로 추론) | **enum으로 강제 (`GAUGE/CUMULATIVE/DELTA/WINDOW`)** |
+| 3 | EAV vs Typed | proto는 typed, Pinot는 EAV | 동일 (송신 typed, 저장 EAV) |
+| 4 | 스레드 모델 | 단일 데몬 스레드 + 별도 sender 큐 | 동일 |
+| 5 | 배치 정책 | N cycle 누적 후 flush (default 6) | 동일 + payload size 임계치 추가 |
+| 6 | 실패 정책 | per-cycle try-catch, NoSuchMethodError 캐치 | **per-collector try-catch까지 한 단계 더** |
+| 7 | 4-튜플 키 | (applicationName, agentId, agentStartTime, timestamp) | + tenantId 미리 박기 |
+
+### 4-2. Core 데이터 모델 (권장 스케치)
+
+```java
+// 1. 식별자 4-tuple
+public record DataPoint(
+    String tenantId,            // 멀티테넌시는 처음부터
+    String applicationName,
+    String agentId,
+    long agentStartTime,        // 재시작 인스턴스 구분
+    long timestamp
+) {}
+
+// 2. 값의 종류 (enum으로 강제)
+public enum MetricValueType {
+    GAUGE,              // heap, threadCount
+    CUMULATIVE,         // GC count
+    DELTA,              // transaction
+    WINDOW              // response time
+}
+
+// 3. 한 cycle snapshot (송신 모델, typed)
+public final class MetricSnapshot {
+    private DataPoint origin;
+    private long collectIntervalMs;
+    private final List<MetricEntry> entries = new ArrayList<>();
+}
+
+public record MetricEntry(
+    String metricName,          // "jvm.gc"
+    String fieldName,           // "heap_used"
+    double value,
+    MetricValueType type,
+    List<Tag> tags
+) {}
+
+// 4. 저장 row (EAV)
+public record MetricRow(
+    String tenantId, long timestamp,
+    String applicationName, String agentId,
+    String sortKey,
+    String metricName, String fieldName,
+    double value, List<Tag> tags,
+    MetricValueType type
+) {}
+
+// 5. Collector 인터페이스
+public interface MetricCollector<S> {
+    String name();
+    boolean isAvailable();      // graceful degradation을 인터페이스에 박음
+    S collect();
+}
+```
+
+### 4-3. Plugin 아키텍처
+
+#### A. SPI
+
+```java
+public interface MetricPlugin {
+    String id();                                  // "jvm.core", "hikari", "tomcat"
+    int order();
+    boolean canActivate(Environment env);          // probe-by-class
+    List<MetricCollector<?>> register(PluginContext ctx);
+}
+```
+
+`META-INF/services/com.your.MetricPlugin` 파일에 구현체 등록 → `ServiceLoader.load(MetricPlugin.class)`로 자동 발견.
+
+#### B. probe-by-class 패턴
+
+```java
+public class HikariPlugin implements MetricPlugin {
+    @Override
+    public boolean canActivate(Environment env) {
+        return ClassUtils.isPresent("com.zaxxer.hikari.HikariDataSource",
+                                    env.classLoader());
+    }
+    @Override
+    public List<MetricCollector<?>> register(PluginContext ctx) {
+        return List.of(new HikariPoolCollector(ctx.mbeanServer()));
+    }
+}
+```
+
+→ HikariCP 안 쓰는 앱에서 `NoClassDefFoundError` 안 남.
+
+#### C. 모듈 분리 권장 구조
+
+```
+apm-agent/
+  agent-core/              ← 의존성 0 (JMX만)
+  agent-bootstrap/         ← premain 진입점
+  plugins/
+    jvm-core/              ← heap, gc, threads, class, fd, buffer
+    jvm-detailed/          ← MemoryPool 분해
+    vendor-oracle/         ← com.sun.management.*
+    vendor-ibm/
+    hikari/
+    tomcat/
+    redis-lettuce/
+    http-okhttp/
+  agent-dist/              ← 최종 jar 빌드 (plugin 묶음 선택)
+```
+
+`vendor-oracle` 같은 경우 `<scope>provided</scope>` + reflection이나 `-Aprocessor` 컴파일 분기로 메인 jar에는 안 들어가게.
+
+#### D. Composite + per-collector 격리
+
+```java
+public class CompositeCollector implements MetricCollector<MetricSnapshot> {
+    private final List<MetricCollector<?>> children;
+    @Override
+    public MetricSnapshot collect() {
+        var snap = new MetricSnapshot();
+        for (var child : children) {
+            if (!child.isAvailable()) continue;
+            try {
+                snap.merge(child.name(), child.collect());
+            } catch (Throwable t) {
+                logger.warn("collector failed: {}", child.name(), t);
+            }
+        }
+        return snap;
+    }
+}
+```
+
+한 collector 실패가 다른 collector를 막지 않게 **try-catch는 composite 레이어에 박음**.
+
+### 4-4. PinotMappers 패턴 적용 (선택)
+
+새 metric 종류 추가의 마찰을 줄이고 싶으면 reflection 기반 자동 등록을 적용:
+
+```java
+public class MetricRouter {
+    public List<TypeMapper<?>> getMappers() {
+        return Arrays.stream(getClass().getDeclaredMethods())
+            .filter(m -> m.getName().startsWith("get") &&
+                         TypeMapper.class.isAssignableFrom(m.getReturnType()))
+            .map(this::invoke)
+            .toList();
+    }
+
+    public TypeMapper<HeapBo> getHeap() {
+        return new TypeMapper<>(Snapshot::getHeapBos, converter::convertHeap);
+    }
+
+    public TypeMapper<GcBo> getGc() {
+        return new TypeMapper<>(Snapshot::getGcBos, converter::convertGc);
+    }
+}
+```
+
+→ 새 metric 추가 = `getXxx()` 메서드 + `convertXxx()` 메서드 두 개만. 다른 코드 손대지 않아도 자동 적재.
+
+### 4-5. graceful degradation 체크리스트
+
+자체 에이전트에 반드시 구현:
+
+- [ ] `NoSuchMethodError` 캐치 후 collector를 `UNSUPPORTED`로 교체
+- [ ] `null` MXBean → `UNCOLLECTED` sentinel 값
+- [ ] `max == -1` (unbounded) → `committed`로 fallback
+- [ ] unknown vendor type → `UnknownXxxMetric` fallback
+- [ ] per-cycle try-catch (CollectJob 레벨)
+- [ ] per-collector try-catch (Composite 레벨)
+- [ ] dataSender 실패 → in-memory ring buffer drop policy + log throttle
+- [ ] 에이전트 자체 OOM 방어 (snapshot list size 임계치)
+- [ ] **에이전트 죽으면 비즈니스 앱이 안 죽는다는 것을 테스트로 증명**
+
+### 4-6. 타이밍 / 클럭 스큐
+
+- 인터벌은 **wall-clock measured**로 보내라 (스케줄 인터벌 신뢰 X)
+- 컬렉터에서 **Now - 10분 이상 과거**는 drop (Pinot/시계열 DB 보호)
+- 같은 agentId라도 `agentStartTime`이 다르면 다른 인스턴스로 취급
+- agent 시계가 미래로 튀는 경우 따로 catch는 안 하는 듯 — NTP 동기화 가정
+
+### 4-7. 스레드 명명 규칙
+
+`PinpointThreadFactory("Pinpoint-stat-monitor", true)` 처럼 **운영자가 jstack 떠서 즉시 식별 가능한 이름**을 박기. 우리도:
+- `apm-stat-monitor` (수집)
+- `apm-stat-sender` (gRPC 송신)
+- `apm-trace-sender`
+- `apm-deadlock-detector`
+
+---
+
+## 6. Pinpoint 코드 reference index
+
+자주 다시 볼 파일 한 곳에:
+
+### 에이전트
+- `agent-module/profiler/.../monitor/DefaultAgentStatMonitor.java:51` — 스케줄러 진입점
+- `agent-module/profiler/.../monitor/CollectJob.java:62` — cycle 메인
+- `agent-module/profiler/.../monitor/collector/AgentStatCollector.java:86` — 12개 sub-collector 묶음
+- `agent-module/profiler/.../monitor/collector/jvmgc/BasicJvmGcMetricCollector.java:42` — JVM GC 수집 예
+- `agent-module/profiler/.../monitor/metric/memory/DefaultMemoryMetric.java:34` — MXBean 호출 예
+- `agent-module/profiler/.../monitor/metric/memory/DefaultDetailedMemoryMetric.java:78` — pool 사용률 변환
+- `agent-module/profiler/.../monitor/metric/transaction/DefaultTransactionMetric.java:96` — delta gauge 패턴
+- `agent-module/profiler/.../context/provider/stat/jvmgc/GarbageCollectorMetricProvider.java:46` — GC 자동 감지
+- `agent-module/profiler-optional/profiler-optional-jdk8/.../cpu/oracle/DefaultCpuLoadMetric.java:38` — vendor 분기
+
+### 컬렉터
+- `collector/.../receiver/grpc/service/StatService.java:75` — gRPC 진입점
+- `collector/.../handler/grpc/metric/AgentMetricBatchHandler.java:38` — 핸들러
+- `collector/.../mapper/grpc/stat/GrpcAgentStatMapper.java:59` — visitor 패턴 매퍼
+- `inspector-collector/.../service/PinotAgentStatService.java:71` — fan-out 진입
+- `inspector-collector/.../service/PinotMappers.java:39` — reflection 자동 등록
+- `inspector-collector/.../model/kafka/AgentStatModelConverter.java:78` — EAV 변환
+- `inspector-collector/.../model/kafka/AgentStat.java:30` — EAV row 정의
+- `inspector-collector/.../dao/pinot/DefaultAgentStatDao.java:51` — Kafka publish
+
+### 웹
+- `inspector-web/.../controller/AgentInspectorStatController.java:52` — 차트 API
+- `commons-timeseries/.../TimeWindowSlotCentricSampler.java:53` — 200 포인트 다운샘플링
+
+---
+
+### 프롬프트 작성 원칙
+
+1. 항상 **reference 파일을 절대 경로**로 명시 — 우리 프로젝트 + Pinpoint 둘 다
+2. 변경 범위를 **번호 매겨서 열거** — "관련 파일 모두" X
+3. **호환성 정책을 미리** — "기존 데이터 어떻게? default 값은?"
+4. **읽기 vs 쓰기를 분리** — "분석만" 명시
+5. **검증 명령어 포함** — `mvn test -pl xxx`
+6. **graceful degradation 정책 매번** — 안 쓰면 LLM이 fail-fast로 짜는 경향
+7. **스레드 이름 같은 운영 디테일도 명시** — jstack 식별성
+
+---
+
+## 8. 안티패턴 / 하지 말 것
+
+| 안티패턴 | 이유 |
+|---------|------|
+| 측정 하나 실패하면 throw | 모니터링이 비즈니스 앱을 죽임 — 절대 금지 |
+| 스케줄 인터벌을 collectInterval로 신뢰 | GC pause 시 TPS 계산 오류 — wall-clock measured 써야 함 |
+| 모든 metric을 untyped double로 | 차트가 누적값/gauge 구분 못함 — 처음부터 enum |
+| Plugin 의존성을 core에 넣기 | 한 plugin 빠지면 에이전트 jar 빌드 실패 — probe-by-class |
+| MBean을 매 cycle 새로 lookup | 비용이 큼 — 부팅 시 1회 lookup 후 캐싱 |
+| send 실패 시 retry storm | 백오프/드롭 정책 필요. 백오프 없는 retry는 컬렉터를 DDoS |
+| agent thread 일반 thread name | 운영자가 jstack에서 식별 불가 — `apm-*` prefix 강제 |
+| 컬렉터 시간 검증 없음 | 클럭 스큐로 시계열 segment 오염 — 10분 timeout 필수 |
+| EAV 변환을 web 레이어에서 | 차트 응답 느려짐 — 수집 시점에 EAV로 변환 |
+
+---
+

--- a/agent-bootstrap/build.gradle
+++ b/agent-bootstrap/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     implementation project(':agent-config')
     implementation project(':agent-core')
     implementation project(':agent-instrument')
+    implementation project(':agent-metric')
     implementation project(':agent-sender')
     implementation project(':plugins:tomcat-plugin')
     implementation project(':plugins:httpclient-plugin')

--- a/agent-bootstrap/src/main/java/com/seeker/agent/bootstrap/AgentMain.java
+++ b/agent-bootstrap/src/main/java/com/seeker/agent/bootstrap/AgentMain.java
@@ -23,6 +23,7 @@ import com.seeker.agent.metric.collector.JvmThreadCollector;
 import com.seeker.agent.metric.collector.SystemCpuCollector;
 import com.seeker.agent.metric.scheduler.MetricScheduler;
 import com.seeker.agent.sender.AsyncSpanDispatcher;
+import com.seeker.agent.sender.GrpcChannelHolder;
 import com.seeker.agent.sender.GrpcMetricSender;
 import com.seeker.agent.sender.GrpcSpanTransport;
 import com.seeker.agent.sender.HttpAgentInfoSender;
@@ -34,12 +35,9 @@ import com.seeker.agent.plugin.http.HttpClientPlugin;
 import com.seeker.agent.plugin.jdbc.JdbcPlugin;
 import com.seeker.agent.plugin.service.ServicePlugin;
 import com.seeker.agent.plugin.was.tomcat.TomcatPlugin;
-import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
 
 import java.lang.instrument.Instrumentation;
 import java.util.Properties;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Java Agent의 진입점 클래스입니다.
@@ -88,20 +86,18 @@ public class AgentMain {
         // 분산 추적 헤더 propagator 등록 (기본: W3C Trace Context)
         PropagatorHolder.setPropagator(new W3CTraceContextPropagator());
 
-        // gRPC 채널을 1개만 생성하여 trace/metric 송신기가 공유한다.
+        // gRPC 채널 holder를 1개만 생성하여 trace/metric 송신기가 공유한다.
+        // io.grpc 의존은 GrpcChannelHolder 내부에 격리되어 본 클래스에서는 보이지 않는다.
         // 채널 위에 각자 별도 stream을 열어 격리하면서 채널 자원·인증은 한 번만 맺는다.
-        // 채널 라이프사이클은 AgentMain이 책임지며, 마지막 shutdown hook에서 종료한다.
-        final ManagedChannel grpcChannel = debugEnabled
+        final GrpcChannelHolder grpcChannelHolder = debugEnabled
                 ? null
-                : ManagedChannelBuilder.forAddress(collectorConfig.getHost(), collectorConfig.getGrpcPort())
-                        .usePlaintext()
-                        .build();
+                : new GrpcChannelHolder(collectorConfig.getHost(), collectorConfig.getGrpcPort());
 
         // DataSender 초기화 및 등록 (Dispatcher + Transport 조합, 디버그 모드 시 Transport는 콘솔)
         SpanTransport transport = debugEnabled
                 ? new ConsoleSpanTransport()
                 : new GrpcSpanTransport(
-                        grpcChannel,
+                        grpcChannelHolder,
                         identityConfig.getAgentName(),
                         identityConfig.getAgentId());
         DataSender sender = new AsyncSpanDispatcher(transport, 1024 * 8);
@@ -128,23 +124,14 @@ public class AgentMain {
 
         // ──────────────── JVM 메트릭 수집 가동 ────────────────
         if (profilerConfig.isMetricEnabled()) {
-            startMetricMonitor(profilerConfig, grpcChannel, debugEnabled, agentInfo);
+            startMetricMonitor(profilerConfig, grpcChannelHolder, debugEnabled, agentInfo);
         }
 
         // 공유 gRPC 채널 종료 hook — trace/metric 종료 후 마지막에 채널 정리.
         // 다른 sender들의 close()는 자기 stream만 정리하고 채널은 안 닫으므로 여기서 일괄 종료.
-        if (grpcChannel != null) {
-            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-                try {
-                    grpcChannel.shutdown();
-                    if (!grpcChannel.awaitTermination(2, TimeUnit.SECONDS)) {
-                        grpcChannel.shutdownNow();
-                    }
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    grpcChannel.shutdownNow();
-                }
-            }, "seeker-grpc-shutdown"));
+        if (grpcChannelHolder != null) {
+            Runtime.getRuntime().addShutdownHook(
+                    new Thread(grpcChannelHolder::close, "seeker-grpc-shutdown"));
         }
 
         System.out.println("[Seeker] Seeker Agent 설치 완료.");
@@ -155,7 +142,7 @@ public class AgentMain {
      * 디버그 모드 → ConsoleMetricSender, 정상 모드 → GrpcMetricSender (공유 채널 + 별도 stream).
      */
     private static void startMetricMonitor(ProfilerConfig profilerConfig,
-                                           ManagedChannel grpcChannel,
+                                           GrpcChannelHolder grpcChannelHolder,
                                            boolean debugEnabled,
                                            AgentInfo agentInfo) {
         MetricRegistry registry = new MetricRegistry();
@@ -168,7 +155,7 @@ public class AgentMain {
         // 송신기 분기 — 정상 모드는 trace와 채널 공유, stream만 별도.
         MetricSender metricSender = debugEnabled
                 ? new ConsoleMetricSender()
-                : new GrpcMetricSender(grpcChannel);
+                : new GrpcMetricSender(grpcChannelHolder);
 
         MetricScheduler scheduler = new MetricScheduler(
                 registry, metricSender, agentInfo,

--- a/agent-bootstrap/src/main/java/com/seeker/agent/bootstrap/AgentMain.java
+++ b/agent-bootstrap/src/main/java/com/seeker/agent/bootstrap/AgentMain.java
@@ -8,25 +8,38 @@ import com.seeker.agent.core.context.ThreadLocalTraceContext;
 import com.seeker.agent.core.context.TraceContextHolder;
 import com.seeker.agent.core.context.propagation.PropagatorHolder;
 import com.seeker.agent.core.context.propagation.W3CTraceContextPropagator;
+import com.seeker.agent.core.metric.MetricRegistry;
+import com.seeker.agent.core.sender.MetricSender;
 import com.seeker.agent.core.model.AgentInfo;
 import com.seeker.agent.core.model.AgentInfoHolder;
 import com.seeker.agent.core.sender.AgentInfoSender;
 import com.seeker.agent.core.sender.DataSender;
 import com.seeker.agent.core.sender.DataSenderHolder;
 import com.seeker.agent.instrument.InstrumentEngine;
+import com.seeker.agent.metric.collector.JvmClassCollector;
+import com.seeker.agent.metric.collector.JvmGcCollector;
+import com.seeker.agent.metric.collector.JvmMemoryCollector;
+import com.seeker.agent.metric.collector.JvmThreadCollector;
+import com.seeker.agent.metric.collector.SystemCpuCollector;
+import com.seeker.agent.metric.scheduler.MetricScheduler;
 import com.seeker.agent.sender.AsyncSpanDispatcher;
-import com.seeker.agent.sender.ConsoleAgentInfoSender;
-import com.seeker.agent.sender.ConsoleSpanTransport;
+import com.seeker.agent.sender.GrpcMetricSender;
 import com.seeker.agent.sender.GrpcSpanTransport;
 import com.seeker.agent.sender.HttpAgentInfoSender;
 import com.seeker.agent.sender.SpanTransport;
+import com.seeker.agent.sender.console.ConsoleAgentInfoSender;
+import com.seeker.agent.sender.console.ConsoleMetricSender;
+import com.seeker.agent.sender.console.ConsoleSpanTransport;
 import com.seeker.agent.plugin.http.HttpClientPlugin;
 import com.seeker.agent.plugin.jdbc.JdbcPlugin;
 import com.seeker.agent.plugin.service.ServicePlugin;
 import com.seeker.agent.plugin.was.tomcat.TomcatPlugin;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
 
 import java.lang.instrument.Instrumentation;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Java Agent의 진입점 클래스입니다.
@@ -75,12 +88,20 @@ public class AgentMain {
         // 분산 추적 헤더 propagator 등록 (기본: W3C Trace Context)
         PropagatorHolder.setPropagator(new W3CTraceContextPropagator());
 
+        // gRPC 채널을 1개만 생성하여 trace/metric 송신기가 공유한다.
+        // 채널 위에 각자 별도 stream을 열어 격리하면서 채널 자원·인증은 한 번만 맺는다.
+        // 채널 라이프사이클은 AgentMain이 책임지며, 마지막 shutdown hook에서 종료한다.
+        final ManagedChannel grpcChannel = debugEnabled
+                ? null
+                : ManagedChannelBuilder.forAddress(collectorConfig.getHost(), collectorConfig.getGrpcPort())
+                        .usePlaintext()
+                        .build();
+
         // DataSender 초기화 및 등록 (Dispatcher + Transport 조합, 디버그 모드 시 Transport는 콘솔)
         SpanTransport transport = debugEnabled
                 ? new ConsoleSpanTransport()
                 : new GrpcSpanTransport(
-                        collectorConfig.getHost(),
-                        collectorConfig.getGrpcPort(),
+                        grpcChannel,
                         identityConfig.getAgentName(),
                         identityConfig.getAgentId());
         DataSender sender = new AsyncSpanDispatcher(transport, 1024 * 8);
@@ -105,6 +126,69 @@ public class AgentMain {
         // instrumentation 설치
         engine.install(inst);
 
+        // ──────────────── JVM 메트릭 수집 가동 ────────────────
+        if (profilerConfig.isMetricEnabled()) {
+            startMetricMonitor(profilerConfig, grpcChannel, debugEnabled, agentInfo);
+        }
+
+        // 공유 gRPC 채널 종료 hook — trace/metric 종료 후 마지막에 채널 정리.
+        // 다른 sender들의 close()는 자기 stream만 정리하고 채널은 안 닫으므로 여기서 일괄 종료.
+        if (grpcChannel != null) {
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                try {
+                    grpcChannel.shutdown();
+                    if (!grpcChannel.awaitTermination(2, TimeUnit.SECONDS)) {
+                        grpcChannel.shutdownNow();
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    grpcChannel.shutdownNow();
+                }
+            }, "seeker-grpc-shutdown"));
+        }
+
         System.out.println("[Seeker] Seeker Agent 설치 완료.");
+    }
+
+    /**
+     * 메트릭 수집기들을 등록하고 스케줄러를 가동한다.
+     * 디버그 모드 → ConsoleMetricSender, 정상 모드 → GrpcMetricSender (공유 채널 + 별도 stream).
+     */
+    private static void startMetricMonitor(ProfilerConfig profilerConfig,
+                                           ManagedChannel grpcChannel,
+                                           boolean debugEnabled,
+                                           AgentInfo agentInfo) {
+        MetricRegistry registry = new MetricRegistry();
+        registry.register(new JvmGcCollector());
+        registry.register(new JvmMemoryCollector());
+        registry.register(new JvmThreadCollector());
+        registry.register(new JvmClassCollector());
+        registry.register(new SystemCpuCollector());
+
+        // 송신기 분기 — 정상 모드는 trace와 채널 공유, stream만 별도.
+        MetricSender metricSender = debugEnabled
+                ? new ConsoleMetricSender()
+                : new GrpcMetricSender(grpcChannel);
+
+        MetricScheduler scheduler = new MetricScheduler(
+                registry, metricSender, agentInfo,
+                profilerConfig.getMetricIntervalMs(),
+                profilerConfig.getMetricBatchSize());
+        scheduler.start();
+
+        // JVM 종료 시 순서 (이 hook):
+        //   1) scheduler.stop()  — 다음 cycle 취소 + 진행 중 cycle 종료 + 잔여 버퍼 flush 시도
+        //   2) sender.close()    — 자기 stream만 정리 (채널은 안 닫음)
+        // 공유 채널 자체는 별도 hook("seeker-grpc-shutdown")에서 일괄 종료된다.
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            scheduler.stop();
+            if (metricSender instanceof java.io.Closeable) {
+                try {
+                    ((java.io.Closeable) metricSender).close();
+                } catch (Exception ignored) {
+                    // shutdown 경로에서는 throw 금지
+                }
+            }
+        }, "seeker-stat-shutdown"));
     }
 }

--- a/agent-config/src/main/java/com/seeker/agent/config/ProfilerConfig.java
+++ b/agent-config/src/main/java/com/seeker/agent/config/ProfilerConfig.java
@@ -18,6 +18,12 @@ public class ProfilerConfig {
     private final String basePackages;
     // 디버그 모드: Collector에 연결하지 않고 수집 데이터를 콘솔에 출력
     private final boolean debugEnabled;
+    // 메트릭 수집 활성화 여부 (전체 on/off)
+    private final boolean metricEnabled;
+    // 메트릭 수집 주기. MetricScheduler에서 [1000, 10000]로 클램프됨.
+    private final long metricIntervalMs;
+    // N cycle 누적 후 batch 전송. 5초 인터벌 × 6 = 30초마다 송신.
+    private final int metricBatchSize;
 
     public ProfilerConfig(Properties properties) {
         this.jdbcEnabled = Boolean.parseBoolean(properties.getProperty("seeker.profiler.jdbc.enabled", "true"));
@@ -28,6 +34,9 @@ public class ProfilerConfig {
         this.samplingRate = Double.parseDouble(properties.getProperty("seeker.profiler.sampling-rate", "1.0"));
         this.basePackages = properties.getProperty("seeker.profiler.base-packages", "");
         this.debugEnabled = Boolean.parseBoolean(properties.getProperty("seeker.profiler.debug.enabled", "false"));
+        this.metricEnabled = Boolean.parseBoolean(properties.getProperty("seeker.metric.enabled", "true"));
+        this.metricIntervalMs = Long.parseLong(properties.getProperty("seeker.metric.interval.ms", "5000"));
+        this.metricBatchSize = Integer.parseInt(properties.getProperty("seeker.metric.batch.size", "6"));
     }
 
     public boolean isJdbcEnabled() {
@@ -58,6 +67,18 @@ public class ProfilerConfig {
         return debugEnabled;
     }
 
+    public boolean isMetricEnabled() {
+        return metricEnabled;
+    }
+
+    public long getMetricIntervalMs() {
+        return metricIntervalMs;
+    }
+
+    public int getMetricBatchSize() {
+        return metricBatchSize;
+    }
+
     @Override
     public String toString() {
         return "ProfilerConfig{" +
@@ -68,6 +89,9 @@ public class ProfilerConfig {
                 ", samplingRate=" + samplingRate +
                 ", basePackages='" + basePackages + '\'' +
                 ", debugEnabled=" + debugEnabled +
+                ", metricEnabled=" + metricEnabled +
+                ", metricIntervalMs=" + metricIntervalMs +
+                ", metricBatchSize=" + metricBatchSize +
                 '}';
     }
 }

--- a/agent-core/src/main/java/com/seeker/agent/core/metric/Metric.java
+++ b/agent-core/src/main/java/com/seeker/agent/core/metric/Metric.java
@@ -1,0 +1,92 @@
+package com.seeker.agent.core.metric;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * 한 메트릭 값을 표현하는 불변 도메인 객체.
+ *
+ * <p>예시:
+ * <pre>
+ *   metricName="jvm.gc"     fieldName="heap_used"        value=12345678   type=GAUGE
+ *   metricName="jvm.gc"     fieldName="count"            value=42         type=CUMULATIVE
+ *                                                                          tags={gc_type:"G1_OLD"}
+ *   metricName="system.cpu" fieldName="jvm_load"         value=0.32       type=GAUGE
+ * </pre>
+ *
+ * <p>{@code metricName} + {@code fieldName} 조합이 식별자 — 차트는 이 둘을 합쳐 "jvm.gc.heap_used"로 표시.
+ * {@code tags}는 같은 fieldName 내에서 차원 분해(예: GC 종류별)에 사용.
+ */
+public final class Metric {
+
+    private final String metricName;
+    private final String fieldName;
+    private final double value;
+    private final MetricValueType type;
+    private final long timestamp;
+    private final Map<String, String> tags;
+
+    public Metric(String metricName, String fieldName, double value,
+                  MetricValueType type, long timestamp, Map<String, String> tags) {
+        this.metricName = metricName;
+        this.fieldName = fieldName;
+        this.value = value;
+        this.type = type;
+        this.timestamp = timestamp;
+        this.tags = (tags == null || tags.isEmpty())
+                ? Collections.emptyMap()
+                : Collections.unmodifiableMap(new LinkedHashMap<>(tags));
+    }
+
+    // -------- factory --------
+
+    /** GAUGE 메트릭 생성 (tags 없음). */
+    public static Metric gauge(String metricName, String fieldName, double value, long timestamp) {
+        return new Metric(metricName, fieldName, value, MetricValueType.GAUGE, timestamp, null);
+    }
+
+    /** GAUGE 메트릭 생성 (tags 포함). */
+    public static Metric gauge(String metricName, String fieldName, double value, long timestamp,
+                               Map<String, String> tags) {
+        return new Metric(metricName, fieldName, value, MetricValueType.GAUGE, timestamp, tags);
+    }
+
+    /** CUMULATIVE 메트릭 생성 (서버에서 차분). */
+    public static Metric cumulative(String metricName, String fieldName, double value, long timestamp) {
+        return new Metric(metricName, fieldName, value, MetricValueType.CUMULATIVE, timestamp, null);
+    }
+
+    /** CUMULATIVE 메트릭 생성 (tags 포함). */
+    public static Metric cumulative(String metricName, String fieldName, double value, long timestamp,
+                                    Map<String, String> tags) {
+        return new Metric(metricName, fieldName, value, MetricValueType.CUMULATIVE, timestamp, tags);
+    }
+
+    /** DELTA 메트릭 생성 (에이전트에서 이미 차분 처리됨). */
+    public static Metric delta(String metricName, String fieldName, double value, long timestamp) {
+        return new Metric(metricName, fieldName, value, MetricValueType.DELTA, timestamp, null);
+    }
+
+    /** WINDOW 메트릭 생성 (한 cycle 윈도우값). */
+    public static Metric window(String metricName, String fieldName, double value, long timestamp) {
+        return new Metric(metricName, fieldName, value, MetricValueType.WINDOW, timestamp, null);
+    }
+
+    // -------- getters --------
+
+    public String getMetricName() { return metricName; }
+    public String getFieldName() { return fieldName; }
+    public double getValue() { return value; }
+    public MetricValueType getType() { return type; }
+    public long getTimestamp() { return timestamp; }
+    public Map<String, String> getTags() { return tags; }
+
+    @Override
+    public String toString() {
+        return "Metric{" + metricName + "." + fieldName + "=" + value
+                + " (" + type + ")"
+                + (tags.isEmpty() ? "" : " tags=" + tags)
+                + " ts=" + timestamp + '}';
+    }
+}

--- a/agent-core/src/main/java/com/seeker/agent/core/metric/MetricCollector.java
+++ b/agent-core/src/main/java/com/seeker/agent/core/metric/MetricCollector.java
@@ -1,0 +1,42 @@
+package com.seeker.agent.core.metric;
+
+import java.util.List;
+
+/**
+ * 단일 메트릭 종류(JVM GC, JVM Memory, System CPU 등)를 수집하는 책임의 인터페이스.
+ *
+ * <p>설계 원칙:
+ * <ul>
+ *   <li>구현체는 부팅 시 1회만 MXBean을 lookup 하고 인스턴스를 캐싱해야 한다 (매 cycle 새로 lookup 금지).</li>
+ *   <li>{@link #isAvailable()}로 graceful degradation을 인터페이스에 강제. JDK/벤더 메서드가 없으면 false 반환.</li>
+ *   <li>{@link #collect(long)}은 절대 throw 하지 않는 게 이상적 — 호출 측({@link MetricRegistry})에서도 잡지만,
+ *       구현체 자체에서 NoSuchMethodError 등을 잡아 빈 리스트 반환하는 패턴이 권장.</li>
+ * </ul>
+ */
+public interface MetricCollector {
+
+    /**
+     * 컬렉터의 식별 이름. 로그 출력 시 어느 collector가 실패했는지 추적용.
+     * 예: "jvm.gc", "jvm.memory", "system.cpu"
+     */
+    String name();
+
+    /**
+     * 이 컬렉터가 현재 환경에서 동작 가능한지 여부.
+     *
+     * <p>예: {@code com.sun.management.OperatingSystemMXBean}이 제공되지 않는 JDK에서는 false.
+     * 부팅 시 {@link MetricRegistry}가 false인 컬렉터를 등록 거부할 수 있다.
+     *
+     * <p>이 시그니처를 인터페이스에 박은 이유: Pinpoint도 vendor 분기 시 graceful degradation을 채택했지만
+     * (try-catch로 UNSUPPORTED 교체) 패턴화는 안 했다. 우리는 인터페이스에 명시해 모든 컬렉터가 강제 준수하게 함.
+     */
+    boolean isAvailable();
+
+    /**
+     * 한 시점의 메트릭들을 수집해 반환한다.
+     *
+     * @param now 수집 시각 (Epoch ms). 이 cycle의 모든 metric이 같은 timestamp를 갖도록 호출자가 전달.
+     * @return 수집된 메트릭 목록. 비어있을 수 있음. {@code null} 반환 금지.
+     */
+    List<Metric> collect(long now);
+}

--- a/agent-core/src/main/java/com/seeker/agent/core/metric/MetricRegistry.java
+++ b/agent-core/src/main/java/com/seeker/agent/core/metric/MetricRegistry.java
@@ -1,0 +1,63 @@
+package com.seeker.agent.core.metric;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * 모든 {@link MetricCollector}를 모아 한 번에 수집하는 composite.
+ *
+ * <p>핵심 책임:
+ * <ul>
+ *   <li>등록 시 {@link MetricCollector#isAvailable()} 검사로 dead collector 걸러냄.</li>
+ *   <li>수집 시 per-collector try-catch로 한 컬렉터 실패가 다른 컬렉터를 막지 않게 격리.</li>
+ * </ul>
+ *
+ * <p>Pinpoint의 Composite + per-collector 격리 패턴과 동일.
+ *
+ * <p>스레드 세이프: {@link CopyOnWriteArrayList}로 등록과 순회를 안전하게 분리. 등록은 부팅 시만 일어나므로
+ * 복사 비용은 무시 가능, 순회(매 cycle)는 락 없이 빠르다.
+ */
+public class MetricRegistry {
+
+    private final List<MetricCollector> collectors = new CopyOnWriteArrayList<>();
+
+    /**
+     * 컬렉터를 등록한다. {@link MetricCollector#isAvailable()}이 false면 무시하고 로그만 남긴다.
+     */
+    public void register(MetricCollector collector) {
+        if (collector == null) return;
+        if (collector.isAvailable()) {
+            collectors.add(collector);
+            System.out.println("[Seeker] metric collector registered: " + collector.name());
+        } else {
+            System.out.println("[Seeker] metric collector unavailable, skipped: " + collector.name());
+        }
+    }
+
+    /**
+     * 등록된 모든 컬렉터에서 메트릭을 수집한다.
+     * 한 컬렉터가 throw 해도 다른 컬렉터의 결과는 보존된다.
+     */
+    public List<Metric> collectAll(long now) {
+        List<Metric> all = new ArrayList<>();
+        for (MetricCollector c : collectors) {
+            try {
+                List<Metric> metrics = c.collect(now);
+                if (metrics != null && !metrics.isEmpty()) {
+                    all.addAll(metrics);
+                }
+            } catch (Throwable t) {
+                // 한 컬렉터 실패가 다른 컬렉터를 막지 않게 격리.
+                // 모니터링 실패가 비즈니스 앱에 영향을 주는 일은 절대 없어야 한다.
+                System.err.println("[Seeker] metric collector failed: " + c.name() + " - " + t);
+            }
+        }
+        return all;
+    }
+
+    /** 등록된 컬렉터 수. 디버깅/로그용. */
+    public int size() {
+        return collectors.size();
+    }
+}

--- a/agent-core/src/main/java/com/seeker/agent/core/metric/MetricSnapshot.java
+++ b/agent-core/src/main/java/com/seeker/agent/core/metric/MetricSnapshot.java
@@ -19,16 +19,14 @@ public final class MetricSnapshot {
 
     private final String applicationName;
     private final String agentId;
-    private final long agentStartTime;
     private final long timestamp;
     private final long collectIntervalMs;
     private final List<Metric> metrics;
 
-    public MetricSnapshot(String applicationName, String agentId, long agentStartTime,
+    public MetricSnapshot(String applicationName, String agentId,
                           long timestamp, long collectIntervalMs, List<Metric> metrics) {
         this.applicationName = applicationName;
         this.agentId = agentId;
-        this.agentStartTime = agentStartTime;
         this.timestamp = timestamp;
         this.collectIntervalMs = collectIntervalMs;
         this.metrics = (metrics == null) ? Collections.emptyList()
@@ -43,7 +41,6 @@ public final class MetricSnapshot {
         return new MetricSnapshot(
                 agentInfo.getAgentName(),
                 agentInfo.getAgentId(),
-                agentInfo.getStartTime(),
                 timestamp,
                 collectIntervalMs,
                 metrics);
@@ -51,7 +48,6 @@ public final class MetricSnapshot {
 
     public String getApplicationName() { return applicationName; }
     public String getAgentId() { return agentId; }
-    public long getAgentStartTime() { return agentStartTime; }
     public long getTimestamp() { return timestamp; }
     public long getCollectIntervalMs() { return collectIntervalMs; }
     public List<Metric> getMetrics() { return metrics; }

--- a/agent-core/src/main/java/com/seeker/agent/core/metric/MetricSnapshot.java
+++ b/agent-core/src/main/java/com/seeker/agent/core/metric/MetricSnapshot.java
@@ -1,0 +1,67 @@
+package com.seeker.agent.core.metric;
+
+import com.seeker.agent.core.model.AgentInfo;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * 한 cycle에 수집된 모든 메트릭의 묶음. 송신 단위.
+ *
+ * <p>4-tuple ID(applicationName, agentId, agentStartTime, timestamp)를 갖는 이유는 Pinpoint와 동일.
+ * 같은 agentId라도 {@code agentStartTime}이 다르면 재시작된 다른 인스턴스로 취급되어 시계열이 분리된다.
+ *
+ * <p>{@code collectIntervalMs}는 <strong>wall-clock measured</strong> 값.
+ * 스케줄러 인터벌(예: 5000ms)이 아니라 실제 측정된 cycle 간 경과 시간을 담는다.
+ * GC pause로 8초가 됐으면 8000을 보낸다 — 서버의 TPS 계산이 정확해지는 핵심 인사이트.
+ */
+public final class MetricSnapshot {
+
+    private final String applicationName;
+    private final String agentId;
+    private final long agentStartTime;
+    private final long timestamp;
+    private final long collectIntervalMs;
+    private final List<Metric> metrics;
+
+    public MetricSnapshot(String applicationName, String agentId, long agentStartTime,
+                          long timestamp, long collectIntervalMs, List<Metric> metrics) {
+        this.applicationName = applicationName;
+        this.agentId = agentId;
+        this.agentStartTime = agentStartTime;
+        this.timestamp = timestamp;
+        this.collectIntervalMs = collectIntervalMs;
+        this.metrics = (metrics == null) ? Collections.emptyList()
+                : Collections.unmodifiableList(metrics);
+    }
+
+    /**
+     * AgentInfo + 시점 정보로부터 편리하게 생성하는 팩토리.
+     */
+    public static MetricSnapshot of(AgentInfo agentInfo, long timestamp,
+                                    long collectIntervalMs, List<Metric> metrics) {
+        return new MetricSnapshot(
+                agentInfo.getAgentName(),
+                agentInfo.getAgentId(),
+                agentInfo.getStartTime(),
+                timestamp,
+                collectIntervalMs,
+                metrics);
+    }
+
+    public String getApplicationName() { return applicationName; }
+    public String getAgentId() { return agentId; }
+    public long getAgentStartTime() { return agentStartTime; }
+    public long getTimestamp() { return timestamp; }
+    public long getCollectIntervalMs() { return collectIntervalMs; }
+    public List<Metric> getMetrics() { return metrics; }
+
+    @Override
+    public String toString() {
+        return "MetricSnapshot{"
+                + "agent=" + agentId
+                + " ts=" + timestamp
+                + " interval=" + collectIntervalMs + "ms"
+                + " count=" + metrics.size() + '}';
+    }
+}

--- a/agent-core/src/main/java/com/seeker/agent/core/metric/MetricValueType.java
+++ b/agent-core/src/main/java/com/seeker/agent/core/metric/MetricValueType.java
@@ -1,0 +1,29 @@
+package com.seeker.agent.core.metric;
+
+/**
+ * 메트릭 값의 의미를 명시하는 enum.
+ *
+ * <p>Pinpoint는 metric 이름으로 서버가 추론하는 비공식 규약이지만,
+ * 본 에이전트는 wire에 명시 필드로 박아 차트/저장 측의 추론 부담을 없앤다.
+ *
+ * <p>차트/집계 측이 이 값을 보고:
+ * <ul>
+ *   <li>{@link #GAUGE}     — 현재값 그대로 표시 (heap_used, threadCount, cpu_load)</li>
+ *   <li>{@link #CUMULATIVE} — 인접 두 시점 차분으로 표시 (gc_count, classes_loaded)</li>
+ *   <li>{@link #DELTA}     — 에이전트가 이미 차분을 보냈으므로 그대로 표시 (transaction)</li>
+ *   <li>{@link #WINDOW}    — 한 cycle 동안의 윈도우값. 다음 cycle에 reset됨 (response_time)</li>
+ * </ul>
+ */
+public enum MetricValueType {
+    /** 폴링 시점의 현재값. 누적/차분 처리 없음. */
+    GAUGE,
+
+    /** 누적값. 인접 두 시점의 차분이 의미있는 값. (서버에서 차분) */
+    CUMULATIVE,
+
+    /** 에이전트에서 이미 직전 cycle 대비 차분으로 변환된 값. */
+    DELTA,
+
+    /** 한 cycle 동안의 윈도우값(예: avg/max). 다음 cycle에서 reset된다. */
+    WINDOW
+}

--- a/agent-core/src/main/java/com/seeker/agent/core/sender/MetricSender.java
+++ b/agent-core/src/main/java/com/seeker/agent/core/sender/MetricSender.java
@@ -1,0 +1,29 @@
+package com.seeker.agent.core.sender;
+
+import com.seeker.agent.core.metric.MetricSnapshot;
+import java.util.List;
+
+/**
+ * 수집된 {@link MetricSnapshot}을 외부(콘솔/gRPC collector)로 내보내는 책임의 인터페이스.
+ *
+ * <p>구현체는 agent-sender 모듈에 둔다 — DataSender(span)와 동일 패턴.
+ * <ul>
+ *   <li>{@code ConsoleMetricSender} — 디버그 모드용</li>
+ *   <li>{@code GrpcMetricSender}    — proto 변환 + gRPC 스트림 전송 (Phase 1.5)</li>
+ * </ul>
+ *
+ * <p>스레드 모델: scheduler 데몬 스레드에서 단일 호출되므로 별도 동기화 불필요.
+ */
+public interface MetricSender {
+
+    /**
+     * batch로 묶인 스냅샷들을 송신한다.
+     *
+     * <p>구현 시 주의:
+     * <ul>
+     *   <li>네트워크/IO 실패해도 절대 throw 하지 않는다 — 스케줄러 cycle을 깨뜨리면 안 됨.</li>
+     *   <li>blocking 호출은 가능하면 짧게. 길어지면 다음 cycle이 밀린다.</li>
+     * </ul>
+     */
+    void send(List<MetricSnapshot> snapshots);
+}

--- a/agent-metric/build.gradle
+++ b/agent-metric/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+    implementation project(':agent-core')
+}

--- a/agent-metric/src/main/java/com/seeker/agent/metric/collector/GcTypeDetector.java
+++ b/agent-metric/src/main/java/com/seeker/agent/metric/collector/GcTypeDetector.java
@@ -1,0 +1,63 @@
+package com.seeker.agent.metric.collector;
+
+import java.lang.management.GarbageCollectorMXBean;
+import java.util.List;
+
+/**
+ * 실행 중인 JVM의 GC 알고리즘을 자동으로 감지해 분류 라벨을 반환하는 유틸리티.
+ *
+ * <p>{@link GarbageCollectorMXBean#getName()}이 반환하는 이름을 매핑한다.
+ * Pinpoint의 {@code GarbageCollectorMetricProvider}와 동일 패턴 — 매칭 실패 시 {@code UNKNOWN} fallback.
+ *
+ * <p>사용처: GC count/time 메트릭의 tags에 GC 타입을 함께 실어 보내, 차트에서 "G1_OLD vs G1_YOUNG" 같은 분리 가능.
+ */
+public final class GcTypeDetector {
+
+    /** GC 알고리즘 분류. tags 값으로 사용된다. */
+    public enum GcType {
+        SERIAL, PARALLEL, CMS, G1, ZGC, SHENANDOAH, UNKNOWN;
+
+        /** 표기 라벨(소문자 hyphen). 차트에서 그대로 사용 가능. */
+        public String label() { return name().toLowerCase().replace('_', '-'); }
+    }
+
+    /**
+     * GarbageCollectorMXBean의 {@code getName()} 결과를 GcType으로 분류.
+     *
+     * <p>대표 매핑:
+     * <ul>
+     *   <li>"Copy", "MarkSweepCompact" → SERIAL</li>
+     *   <li>"PS Scavenge", "PS MarkSweep" → PARALLEL</li>
+     *   <li>"ParNew", "ConcurrentMarkSweep" → CMS</li>
+     *   <li>"G1 Young Generation", "G1 Old Generation" → G1</li>
+     *   <li>"ZGC Minor Pauses", "ZGC Major Pauses", "ZGC" → ZGC</li>
+     *   <li>"Shenandoah Pauses", "Shenandoah Cycles" → SHENANDOAH</li>
+     * </ul>
+     */
+    public static GcType classify(String gcName) {
+        if (gcName == null) return GcType.UNKNOWN;
+        String n = gcName.toLowerCase();
+        if (n.contains("g1")) return GcType.G1;
+        if (n.contains("zgc") || n.equals("zgc")) return GcType.ZGC;
+        if (n.contains("shenandoah")) return GcType.SHENANDOAH;
+        if (n.contains("ps ")) return GcType.PARALLEL;
+        if (n.contains("parnew") || n.contains("concurrentmarksweep")) return GcType.CMS;
+        if (n.contains("copy") || n.contains("marksweepcompact")) return GcType.SERIAL;
+        return GcType.UNKNOWN;
+    }
+
+    /**
+     * 등록된 모든 GC bean에서 가장 대표적인 GC 알고리즘을 추정한다.
+     * 부팅 시 1회 호출 후 캐싱하는 용도. (Pinpoint:46 패턴)
+     */
+    public static GcType detectPrimary(List<GarbageCollectorMXBean> beans) {
+        if (beans == null || beans.isEmpty()) return GcType.UNKNOWN;
+        for (GarbageCollectorMXBean bean : beans) {
+            GcType type = classify(bean.getName());
+            if (type != GcType.UNKNOWN) return type;
+        }
+        return GcType.UNKNOWN;
+    }
+
+    private GcTypeDetector() {}
+}

--- a/agent-metric/src/main/java/com/seeker/agent/metric/collector/JvmClassCollector.java
+++ b/agent-metric/src/main/java/com/seeker/agent/metric/collector/JvmClassCollector.java
@@ -1,0 +1,54 @@
+package com.seeker.agent.metric.collector;
+
+import com.seeker.agent.core.metric.Metric;
+import com.seeker.agent.core.metric.MetricCollector;
+
+import java.lang.management.ClassLoadingMXBean;
+import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 클래스 로딩 통계를 수집하는 컬렉터.
+ *
+ * <p>측정 항목:
+ * <ul>
+ *   <li>{@code jvm.class.loaded_count}        — 현재 로드된 클래스 수 (GAUGE)</li>
+ *   <li>{@code jvm.class.total_loaded_count}  — 시작 이후 누적 로드 (CUMULATIVE)</li>
+ *   <li>{@code jvm.class.unloaded_count}      — 시작 이후 누적 언로드 (CUMULATIVE)</li>
+ * </ul>
+ *
+ * <p>{@code total_loaded_count}가 운영 중에도 계속 증가하면 동적 클래스 생성(예: dynamic proxy 폭증, 람다 메가모프 사이트)
+ * 등을 의심할 수 있는 신호.
+ */
+public class JvmClassCollector implements MetricCollector {
+
+    private static final String METRIC_NAME = "jvm.class";
+
+    private final ClassLoadingMXBean classBean;
+
+    public JvmClassCollector() {
+        this.classBean = ManagementFactory.getClassLoadingMXBean();
+    }
+
+    @Override
+    public String name() {
+        return METRIC_NAME;
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return classBean != null;
+    }
+
+    @Override
+    public List<Metric> collect(long now) {
+        List<Metric> out = new ArrayList<>(3);
+        out.add(Metric.gauge(METRIC_NAME, "loaded_count", classBean.getLoadedClassCount(), now));
+        out.add(Metric.cumulative(METRIC_NAME, "total_loaded_count",
+                classBean.getTotalLoadedClassCount(), now));
+        out.add(Metric.cumulative(METRIC_NAME, "unloaded_count",
+                classBean.getUnloadedClassCount(), now));
+        return out;
+    }
+}

--- a/agent-metric/src/main/java/com/seeker/agent/metric/collector/JvmGcCollector.java
+++ b/agent-metric/src/main/java/com/seeker/agent/metric/collector/JvmGcCollector.java
@@ -1,0 +1,66 @@
+package com.seeker.agent.metric.collector;
+
+import com.seeker.agent.core.metric.Metric;
+import com.seeker.agent.core.metric.MetricCollector;
+
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * GC count / time을 수집하는 컬렉터.
+ *
+ * <p>측정 항목:
+ * <ul>
+ *   <li>{@code jvm.gc.count}   — 누적 GC 횟수 (CUMULATIVE — 서버에서 차분)</li>
+ *   <li>{@code jvm.gc.time_ms} — 누적 GC 소요 시간 (CUMULATIVE)</li>
+ * </ul>
+ *
+ * <p>tags:
+ * <ul>
+ *   <li>{@code gc_type} — {@link GcTypeDetector.GcType}으로 분류된 알고리즘 (예: "g1", "zgc")</li>
+ *   <li>{@code gc_name} — MXBean 원본 이름 (예: "G1 Young Generation")</li>
+ * </ul>
+ *
+ * <p>차트는 {@code gc_type} tag로 GC 알고리즘별 시리즈 분리, {@code gc_name}으로 young/old 구분 가능.
+ */
+public class JvmGcCollector implements MetricCollector {
+
+    private static final String METRIC_NAME = "jvm.gc";
+
+    private final List<GarbageCollectorMXBean> gcBeans;
+
+    public JvmGcCollector() {
+        // 부팅 시 1회 lookup. JVM 가동 중 GC bean 목록은 변하지 않는다.
+        this.gcBeans = ManagementFactory.getGarbageCollectorMXBeans();
+    }
+
+    @Override
+    public String name() {
+        return METRIC_NAME;
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return gcBeans != null && !gcBeans.isEmpty();
+    }
+
+    @Override
+    public List<Metric> collect(long now) {
+        List<Metric> out = new ArrayList<>(gcBeans.size() * 2);
+        for (GarbageCollectorMXBean bean : gcBeans) {
+            // 매 GC bean마다 tags를 따로 만들어 어떤 GC인지 식별 가능하게.
+            Map<String, String> tags = new LinkedHashMap<>(2);
+            tags.put("gc_type", GcTypeDetector.classify(bean.getName()).label());
+            tags.put("gc_name", bean.getName());
+
+            // CUMULATIVE: 누적값을 그대로 보내고, 서버가 차분을 계산.
+            out.add(Metric.cumulative(METRIC_NAME, "count", bean.getCollectionCount(), now, tags));
+            out.add(Metric.cumulative(METRIC_NAME, "time_ms", bean.getCollectionTime(), now, tags));
+        }
+        return out;
+    }
+}

--- a/agent-metric/src/main/java/com/seeker/agent/metric/collector/JvmMemoryCollector.java
+++ b/agent-metric/src/main/java/com/seeker/agent/metric/collector/JvmMemoryCollector.java
@@ -1,0 +1,71 @@
+package com.seeker.agent.metric.collector;
+
+import com.seeker.agent.core.metric.Metric;
+import com.seeker.agent.core.metric.MetricCollector;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.lang.management.MemoryUsage;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * JVM 힙/논힙 메모리 사용량을 수집하는 컬렉터.
+ *
+ * <p>측정 항목:
+ * <ul>
+ *   <li>{@code jvm.memory.heap_used}      — 현재 사용 중 (GAUGE)</li>
+ *   <li>{@code jvm.memory.heap_committed} — JVM이 OS로부터 확보한 힙 (GAUGE)</li>
+ *   <li>{@code jvm.memory.heap_max}       — 힙 최대치. {@code -1}이면 committed로 fallback</li>
+ *   <li>{@code jvm.memory.nonheap_used}   — Metaspace/CodeCache 등 (GAUGE)</li>
+ *   <li>{@code jvm.memory.nonheap_committed}</li>
+ *   <li>{@code jvm.memory.nonheap_max}    — 마찬가지로 -1 fallback</li>
+ * </ul>
+ *
+ * <p>{@link MemoryMXBean}은 부팅 시 1회만 lookup해 캐싱 (Pinpoint 패턴).
+ */
+public class JvmMemoryCollector implements MetricCollector {
+
+    private static final String METRIC_NAME = "jvm.memory";
+
+    private final MemoryMXBean memoryBean;
+
+    public JvmMemoryCollector() {
+        // 매 cycle 새로 가져오지 않고 부팅 시 1회 lookup. ManagementFactory는 같은 인스턴스 반환을 보장.
+        this.memoryBean = ManagementFactory.getMemoryMXBean();
+    }
+
+    @Override
+    public String name() {
+        return METRIC_NAME;
+    }
+
+    @Override
+    public boolean isAvailable() {
+        // MemoryMXBean은 표준 JDK 제공이므로 사실상 항상 true.
+        // 안전망으로 null 체크만.
+        try {
+            return memoryBean != null && memoryBean.getHeapMemoryUsage() != null;
+        } catch (Throwable t) {
+            return false;
+        }
+    }
+
+    @Override
+    public List<Metric> collect(long now) {
+        List<Metric> out = new ArrayList<>(6);
+        MemoryUsage heap = memoryBean.getHeapMemoryUsage();
+        out.add(Metric.gauge(METRIC_NAME, "heap_used", heap.getUsed(), now));
+        out.add(Metric.gauge(METRIC_NAME, "heap_committed", heap.getCommitted(), now));
+        // max == -1 (unbounded, 예: ZGC Metaspace)이면 committed로 fallback. Pinpoint:78 패턴.
+        out.add(Metric.gauge(METRIC_NAME, "heap_max",
+                heap.getMax() == -1 ? heap.getCommitted() : heap.getMax(), now));
+
+        MemoryUsage nonHeap = memoryBean.getNonHeapMemoryUsage();
+        out.add(Metric.gauge(METRIC_NAME, "nonheap_used", nonHeap.getUsed(), now));
+        out.add(Metric.gauge(METRIC_NAME, "nonheap_committed", nonHeap.getCommitted(), now));
+        out.add(Metric.gauge(METRIC_NAME, "nonheap_max",
+                nonHeap.getMax() == -1 ? nonHeap.getCommitted() : nonHeap.getMax(), now));
+        return out;
+    }
+}

--- a/agent-metric/src/main/java/com/seeker/agent/metric/collector/JvmThreadCollector.java
+++ b/agent-metric/src/main/java/com/seeker/agent/metric/collector/JvmThreadCollector.java
@@ -1,0 +1,54 @@
+package com.seeker.agent.metric.collector;
+
+import com.seeker.agent.core.metric.Metric;
+import com.seeker.agent.core.metric.MetricCollector;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 스레드 개수를 수집하는 컬렉터.
+ *
+ * <p>측정 항목:
+ * <ul>
+ *   <li>{@code jvm.thread.count}        — 현재 스레드 수 (GAUGE)</li>
+ *   <li>{@code jvm.thread.daemon_count} — 데몬 스레드 수 (GAUGE)</li>
+ *   <li>{@code jvm.thread.peak_count}   — 시작 이후 피크 스레드 수 (CUMULATIVE 성격이지만 표시는 GAUGE)</li>
+ *   <li>{@code jvm.thread.total_started_count} — 시작 이후 누적 생성 스레드 수 (CUMULATIVE)</li>
+ * </ul>
+ *
+ * <p>스레드 leak 의심 상황 분석에 유용 — peak가 계속 우상향한다면 스레드를 정리하지 않는 코드 의심.
+ */
+public class JvmThreadCollector implements MetricCollector {
+
+    private static final String METRIC_NAME = "jvm.thread";
+
+    private final ThreadMXBean threadBean;
+
+    public JvmThreadCollector() {
+        this.threadBean = ManagementFactory.getThreadMXBean();
+    }
+
+    @Override
+    public String name() {
+        return METRIC_NAME;
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return threadBean != null;
+    }
+
+    @Override
+    public List<Metric> collect(long now) {
+        List<Metric> out = new ArrayList<>(4);
+        out.add(Metric.gauge(METRIC_NAME, "count", threadBean.getThreadCount(), now));
+        out.add(Metric.gauge(METRIC_NAME, "daemon_count", threadBean.getDaemonThreadCount(), now));
+        out.add(Metric.gauge(METRIC_NAME, "peak_count", threadBean.getPeakThreadCount(), now));
+        out.add(Metric.cumulative(METRIC_NAME, "total_started_count",
+                threadBean.getTotalStartedThreadCount(), now));
+        return out;
+    }
+}

--- a/agent-metric/src/main/java/com/seeker/agent/metric/collector/SystemCpuCollector.java
+++ b/agent-metric/src/main/java/com/seeker/agent/metric/collector/SystemCpuCollector.java
@@ -1,0 +1,116 @@
+package com.seeker.agent.metric.collector;
+
+import com.seeker.agent.core.metric.Metric;
+import com.seeker.agent.core.metric.MetricCollector;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.OperatingSystemMXBean;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * JVM/시스템 CPU 사용률 + 시스템 부하를 수집하는 컬렉터.
+ *
+ * <p>측정 항목 (모두 GAUGE):
+ * <ul>
+ *   <li>{@code system.cpu.jvm_load}    — JVM 프로세스 CPU 사용률 (0.0~1.0)</li>
+ *   <li>{@code system.cpu.system_load} — 시스템 전체 CPU 사용률 (0.0~1.0)</li>
+ *   <li>{@code system.cpu.load_average} — system load average / CPU 코어 수 (Unix만)</li>
+ * </ul>
+ *
+ * <p>{@code com.sun.management.OperatingSystemMXBean}이 제공하는 메서드를 reflection으로 호출 — Oracle/OpenJDK
+ * 외 일부 JDK(IBM J9 등)에서 메서드가 없을 수 있어 graceful degradation을 위해 직접 cast 대신 reflection 사용.
+ * Pinpoint의 vendor 분기 패턴과 동일 의도.
+ *
+ * <p>한 번이라도 메서드 lookup 실패하면 해당 metric만 빠지고 나머지는 정상 수집된다.
+ */
+public class SystemCpuCollector implements MetricCollector {
+
+    private static final String METRIC_NAME = "system.cpu";
+
+    private final OperatingSystemMXBean osBean;
+    private final Method getProcessCpuLoad;   // com.sun.management.OperatingSystemMXBean#getProcessCpuLoad
+    private final Method getSystemCpuLoad;    // com.sun.management.OperatingSystemMXBean#getCpuLoad (JDK 14+)
+                                              // 또는 #getSystemCpuLoad (이전)
+    private final int availableProcessors;
+
+    public SystemCpuCollector() {
+        this.osBean = ManagementFactory.getOperatingSystemMXBean();
+        this.availableProcessors = (osBean != null) ? osBean.getAvailableProcessors() : 1;
+        this.getProcessCpuLoad = lookup(osBean, "getProcessCpuLoad");
+        // JDK 14+에서는 getCpuLoad, 이전에는 getSystemCpuLoad. 둘 다 시도.
+        Method m = lookup(osBean, "getCpuLoad");
+        if (m == null) m = lookup(osBean, "getSystemCpuLoad");
+        this.getSystemCpuLoad = m;
+    }
+
+    /**
+     * 메서드를 reflection으로 안전하게 lookup. 없으면 null 반환 (graceful degradation).
+     */
+    private static Method lookup(Object target, String methodName) {
+        if (target == null) return null;
+        try {
+            Method m = target.getClass().getMethod(methodName);
+            m.setAccessible(true);
+            return m;
+        } catch (Throwable t) {
+            return null;
+        }
+    }
+
+    /**
+     * lookup된 메서드를 호출해 double 결과를 안전하게 반환.
+     * 호출 실패 시 -1 반환 (수집 불가 표시).
+     */
+    private double invokeDouble(Method m) {
+        if (m == null) return -1;
+        try {
+            Object result = m.invoke(osBean);
+            if (result instanceof Double) {
+                double v = (Double) result;
+                // 메서드 명세상 -1 또는 NaN이 나올 수 있음 — 그대로 -1로 통일.
+                if (Double.isNaN(v) || v < 0) return -1;
+                return v;
+            }
+            return -1;
+        } catch (Throwable t) {
+            return -1;
+        }
+    }
+
+    @Override
+    public String name() {
+        return METRIC_NAME;
+    }
+
+    @Override
+    public boolean isAvailable() {
+        // 두 메서드 중 하나라도 있으면 의미있는 값 수집 가능.
+        return osBean != null && (getProcessCpuLoad != null || getSystemCpuLoad != null);
+    }
+
+    @Override
+    public List<Metric> collect(long now) {
+        List<Metric> out = new ArrayList<>(3);
+
+        double jvmLoad = invokeDouble(getProcessCpuLoad);
+        if (jvmLoad >= 0) {
+            out.add(Metric.gauge(METRIC_NAME, "jvm_load", jvmLoad, now));
+        }
+
+        double systemLoad = invokeDouble(getSystemCpuLoad);
+        if (systemLoad >= 0) {
+            out.add(Metric.gauge(METRIC_NAME, "system_load", systemLoad, now));
+        }
+
+        // load average — Unix에서만 의미있음 (Windows는 -1 반환)
+        double loadAvg = osBean.getSystemLoadAverage();
+        if (loadAvg >= 0 && availableProcessors > 0) {
+            // 코어 수로 나눠 1.0 = 100% 부하 의미로 정규화. 차트 친화적.
+            out.add(Metric.gauge(METRIC_NAME, "load_average", loadAvg / availableProcessors, now));
+        }
+
+        return out;
+    }
+}

--- a/agent-metric/src/main/java/com/seeker/agent/metric/scheduler/MetricScheduler.java
+++ b/agent-metric/src/main/java/com/seeker/agent/metric/scheduler/MetricScheduler.java
@@ -1,0 +1,160 @@
+package com.seeker.agent.metric.scheduler;
+
+import com.seeker.agent.core.metric.Metric;
+import com.seeker.agent.core.metric.MetricRegistry;
+import com.seeker.agent.core.sender.MetricSender;
+import com.seeker.agent.core.metric.MetricSnapshot;
+import com.seeker.agent.core.model.AgentInfo;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * 메트릭 수집 cycle을 주기적으로 실행하고 batch로 송신하는 스케줄러.
+ *
+ * <p>Pinpoint의 {@code DefaultAgentStatMonitor} + {@code CollectJob} 패턴 차용:
+ * <ul>
+ *   <li>단일 <strong>데몬 스레드</strong> (jstack 식별성을 위해 이름 박음 — {@code seeker-stat-monitor})</li>
+ *   <li>인터벌은 [1s, 10s]로 clamp — 너무 짧으면 부하, 너무 길면 dashboard 무의미</li>
+ *   <li><strong>wall-clock measured interval</strong>: 스케줄 인터벌 신뢰 X. GC pause로 8초 됐으면 8000을 보냄.
+ *       서버의 TPS 계산 정확성에 영향.</li>
+ *   <li><strong>N cycle 누적 후 batch flush</strong> (default 6) — gRPC 호출 횟수 절감</li>
+ *   <li><strong>list-swap</strong>: flush 시 새 ArrayList를 할당하고 기존 리스트는 sender에 넘김 → lock-free</li>
+ *   <li><strong>pre-load class trick</strong>: start() 직전 collectAll()을 미리 1~2회 호출.
+ *       JDK 6 시절 classloader deadlock(#2881) 회피용 안전 보험.</li>
+ *   <li><strong>per-cycle try-catch</strong>: 한 cycle 실패가 다음 cycle에 영향 없도록.</li>
+ * </ul>
+ */
+public class MetricScheduler {
+
+    /** 인터벌 하한. 너무 짧으면 수집/송신 비용이 비즈니스 처리 영향. */
+    public static final long MIN_INTERVAL_MS = 1000;
+
+    /** 인터벌 상한. 너무 길면 메트릭이 사실상 무의미. */
+    public static final long MAX_INTERVAL_MS = 10_000;
+
+    /** 기본 batch size — 5초 인터벌이면 30초마다 송신. */
+    public static final int DEFAULT_BATCH_SIZE = 6;
+
+    private final ScheduledExecutorService executor;
+    private final MetricRegistry registry;
+    private final MetricSender sender;
+    private final AgentInfo agentInfo;
+    private final long intervalMs;
+    private final int batchSize;
+
+    /** 직전 cycle의 timestamp. wall-clock measured interval 계산용. */
+    private long prevTimestamp = -1;
+
+    /** N cycle 누적 버퍼. flush 시 새 인스턴스로 swap. */
+    private List<MetricSnapshot> buffer;
+
+    private ScheduledFuture<?> future;
+
+    public MetricScheduler(MetricRegistry registry, MetricSender sender, AgentInfo agentInfo,
+                           long intervalMs, int batchSize) {
+        this.registry = registry;
+        this.sender = sender;
+        this.agentInfo = agentInfo;
+        // 인터벌 clamp — 외부 설정이 극단치여도 안전한 범위 강제.
+        this.intervalMs = Math.max(MIN_INTERVAL_MS, Math.min(MAX_INTERVAL_MS, intervalMs));
+        this.batchSize = (batchSize <= 0) ? DEFAULT_BATCH_SIZE : batchSize;
+        this.buffer = new ArrayList<>(this.batchSize);
+
+        // 데몬 스레드 + 식별 가능한 이름.
+        // 데몬: 메트릭 스레드가 비-데몬이면 JVM 종료를 막을 수 있음.
+        // 이름: jstack 떠서 즉시 식별 가능하게.
+        this.executor = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "seeker-stat-monitor");
+            t.setDaemon(true);
+            return t;
+        });
+    }
+
+    /**
+     * 스케줄러를 시작한다. {@link #start()}가 한 번 호출된 후 재호출은 무시.
+     */
+    public synchronized void start() {
+        if (future != null) {
+            return;  // 이미 시작됨
+        }
+
+        // pre-load class trick (Pinpoint #2881 회피용 안전 보험).
+        // 스케줄러 첫 가동 시점에 일어나는 클래스 로딩이 다른 스레드와 충돌하지 않도록 사전 워밍업.
+        try { registry.collectAll(System.currentTimeMillis()); } catch (Throwable ignored) {}
+        try { registry.collectAll(System.currentTimeMillis()); } catch (Throwable ignored) {}
+
+        future = executor.scheduleAtFixedRate(this::runOnce,
+                intervalMs, intervalMs, TimeUnit.MILLISECONDS);
+
+        System.out.println("[Seeker] metric scheduler started: interval=" + intervalMs
+                + "ms batch=" + batchSize + " collectors=" + registry.size());
+    }
+
+    /**
+     * 한 cycle 처리. ScheduledExecutor에서 단일 스레드로만 호출되므로 락 불필요.
+     */
+    private void runOnce() {
+        try {
+            long now = System.currentTimeMillis();
+
+            // wall-clock measured interval. 첫 호출은 0으로 둔다 (에이전트 시작 직후 spike 방지).
+            long measuredInterval = (prevTimestamp < 0) ? 0 : (now - prevTimestamp);
+            prevTimestamp = now;
+
+            List<Metric> metrics = registry.collectAll(now);
+            MetricSnapshot snapshot = MetricSnapshot.of(agentInfo, now, measuredInterval, metrics);
+            buffer.add(snapshot);
+
+            // batchSize에 도달하면 flush.
+            if (buffer.size() >= batchSize) {
+                flush();
+            }
+        } catch (Throwable t) {
+            // 한 cycle 실패가 다음 cycle을 막지 않게. 모니터링 실패 → 비즈니스 영향은 절대 금지.
+            System.err.println("[Seeker] metric cycle failed: " + t);
+        }
+    }
+
+    /**
+     * 버퍼를 swap하여 sender에게 넘기고 새 버퍼를 할당.
+     * list-swap 패턴: producer(scheduler thread)가 새 리스트 만들고, consumer(sender)는 기존 리스트를 받음.
+     * 락 없이 producer/consumer 분리.
+     */
+    private void flush() {
+        if (buffer.isEmpty()) return;
+        List<MetricSnapshot> toSend = buffer;
+        buffer = new ArrayList<>(batchSize);
+        try {
+            sender.send(toSend);
+        } catch (Throwable t) {
+            // sender 자체가 throw 하지 않도록 구현하지만 안전망.
+            System.err.println("[Seeker] metric send failed: " + t);
+        }
+    }
+
+    /**
+     * 스케줄러 정지. JVM 종료 hook이나 테스트에서 호출. 남은 버퍼는 마지막으로 flush 시도.
+     */
+    public synchronized void stop() {
+        if (future != null) {
+            future.cancel(false);
+            future = null;
+        }
+        executor.shutdown();
+        try {
+            if (!executor.awaitTermination(2, TimeUnit.SECONDS)) {
+                executor.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            executor.shutdownNow();
+        }
+        // 마지막 잔여 버퍼 flush (best-effort).
+        try { flush(); } catch (Throwable ignored) {}
+    }
+}

--- a/agent-sender/src/main/java/com/seeker/agent/sender/GrpcChannelHolder.java
+++ b/agent-sender/src/main/java/com/seeker/agent/sender/GrpcChannelHolder.java
@@ -1,0 +1,69 @@
+package com.seeker.agent.sender;
+
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+
+import java.io.Closeable;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * trace/metric 송신기들이 공유하는 gRPC {@link ManagedChannel}을 감싸는 wrapper.
+ *
+ * <p>이 클래스의 존재 이유는 {@code io.grpc} 의존성을 sender 모듈 내부로 격리시키는 것.
+ * agent-bootstrap 등 외부 모듈은 {@link ManagedChannel}을 직접 보지 않고 본 holder만 다룬다.
+ *
+ * <p>채널 접근 메서드 {@link #channel()}은 <strong>package-private</strong>으로 선언되어
+ * 같은 패키지({@code com.seeker.agent.sender})의 sender 구현체만 호출할 수 있다.
+ * 외부 모듈에서 {@code holder.channel()}을 호출하려 하면 컴파일 에러.
+ *
+ * <p>라이프사이클:
+ * <ul>
+ *   <li>생성자에서 채널 즉시 build</li>
+ *   <li>{@link #close()}에서 graceful shutdown(2초) 후 강제 종료</li>
+ * </ul>
+ */
+public class GrpcChannelHolder implements Closeable {
+
+    private static final long SHUTDOWN_AWAIT_SECONDS = 2;
+
+    private final ManagedChannel channel;
+
+    public GrpcChannelHolder(String host, int port) {
+        this.channel = ManagedChannelBuilder.forAddress(host, port)
+                .usePlaintext()
+                .build();
+    }
+
+    /**
+     * 같은 패키지의 sender만 접근 가능한 채널 핸들.
+     * <strong>외부 모듈에서 호출 불가 (package-private).</strong>
+     */
+    ManagedChannel channel() {
+        return channel;
+    }
+
+    /**
+     * 진행 중 RPC가 정리될 시간을 짧게 준 뒤 강제 종료.
+     * shutdown hook 등에서 1회만 호출하면 된다.
+     */
+    @Override
+    public void close() {
+        try {
+            channel.shutdown();
+            if (!channel.awaitTermination(SHUTDOWN_AWAIT_SECONDS, TimeUnit.SECONDS)) {
+                channel.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            channel.shutdownNow();
+        } catch (Throwable t) {
+            // close 경로에서 throw 금지
+            System.err.println("[Seeker] grpc channel close 에러: " + t.getMessage());
+        }
+    }
+
+    /** 디버깅용 — 채널 인증 권한 문자열 (host:port). */
+    public String authority() {
+        return channel.authority();
+    }
+}

--- a/agent-sender/src/main/java/com/seeker/agent/sender/GrpcMetricConverter.java
+++ b/agent-sender/src/main/java/com/seeker/agent/sender/GrpcMetricConverter.java
@@ -1,0 +1,81 @@
+package com.seeker.agent.sender;
+
+import com.seeker.agent.core.metric.Metric;
+import com.seeker.agent.core.metric.MetricSnapshot;
+import com.seeker.agent.core.metric.MetricValueType;
+import com.seeker.collector.global.grpc.DataMessage;
+
+/**
+ * 도메인 {@link MetricSnapshot}을 gRPC proto {@link DataMessage}로 변환하는 컨버터.
+ *
+ * <p>{@code GrpcDataMessageConverter}(Span 변환)와 같은 책임 분리 패턴 — sender는 컨버터에 변환을 위임하고
+ * 자기는 채널/스트림 라이프사이클만 담당.
+ */
+public class GrpcMetricConverter {
+
+    /**
+     * 도메인 스냅샷을 wire 메시지로 변환한다.
+     *
+     * <p>변환 규칙:
+     * <ul>
+     *   <li>4-tuple ID(applicationName, agentId, agentStartTime, timestamp)는 1:1 매핑</li>
+     *   <li>{@code collectIntervalMs}는 그대로 — wall-clock measured 의미 보존</li>
+     *   <li>각 {@link Metric}은 {@code MetricPoint}로 변환되고 tags는 그대로 복사</li>
+     *   <li>null 문자열은 빈 문자열로 보정 (proto3는 null을 표현 못함)</li>
+     * </ul>
+     */
+    public DataMessage toDataMessage(MetricSnapshot snapshot) {
+        com.seeker.collector.global.grpc.MetricSnapshot.Builder builder =
+                com.seeker.collector.global.grpc.MetricSnapshot.newBuilder()
+                        .setApplicationName(nullSafe(snapshot.getApplicationName()))
+                        .setAgentId(nullSafe(snapshot.getAgentId()))
+                        .setAgentStartTime(snapshot.getAgentStartTime())
+                        .setTimestamp(snapshot.getTimestamp())
+                        .setCollectIntervalMs(snapshot.getCollectIntervalMs());
+
+        for (Metric m : snapshot.getMetrics()) {
+            builder.addPoints(toProtoPoint(m));
+        }
+
+        return DataMessage.newBuilder()
+                .setMetricSnapshot(builder.build())
+                .build();
+    }
+
+    /**
+     * 도메인 {@link Metric} → proto {@code MetricPoint}.
+     */
+    private com.seeker.collector.global.grpc.MetricPoint toProtoPoint(Metric m) {
+        com.seeker.collector.global.grpc.MetricPoint.Builder pb =
+                com.seeker.collector.global.grpc.MetricPoint.newBuilder()
+                        .setMetricName(nullSafe(m.getMetricName()))
+                        .setFieldName(nullSafe(m.getFieldName()))
+                        .setValue(m.getValue())
+                        .setType(toProtoType(m.getType()));
+
+        // tags는 immutable map. 비어있어도 putAllTags(emptyMap)는 안전.
+        if (m.getTags() != null && !m.getTags().isEmpty()) {
+            pb.putAllTags(m.getTags());
+        }
+        return pb.build();
+    }
+
+    /**
+     * 도메인 enum → proto enum 매핑.
+     * 새 값이 도메인에 추가되면 컴파일러가 default 분기로 떨어지는 걸 잡아 알려줌(switch exhaustive 보장 안 됨에 유의).
+     */
+    private com.seeker.collector.global.grpc.MetricValueType toProtoType(MetricValueType t) {
+        if (t == null) return com.seeker.collector.global.grpc.MetricValueType.GAUGE;
+        switch (t) {
+            case GAUGE:      return com.seeker.collector.global.grpc.MetricValueType.GAUGE;
+            case CUMULATIVE: return com.seeker.collector.global.grpc.MetricValueType.CUMULATIVE;
+            case DELTA:      return com.seeker.collector.global.grpc.MetricValueType.DELTA;
+            case WINDOW:     return com.seeker.collector.global.grpc.MetricValueType.WINDOW;
+            default:         return com.seeker.collector.global.grpc.MetricValueType.GAUGE;
+        }
+    }
+
+    private static String nullSafe(String s) {
+        return s == null ? "" : s;
+    }
+}

--- a/agent-sender/src/main/java/com/seeker/agent/sender/GrpcMetricConverter.java
+++ b/agent-sender/src/main/java/com/seeker/agent/sender/GrpcMetricConverter.java
@@ -29,7 +29,6 @@ public class GrpcMetricConverter {
                 com.seeker.collector.global.grpc.MetricSnapshot.newBuilder()
                         .setApplicationName(nullSafe(snapshot.getApplicationName()))
                         .setAgentId(nullSafe(snapshot.getAgentId()))
-                        .setAgentStartTime(snapshot.getAgentStartTime())
                         .setTimestamp(snapshot.getTimestamp())
                         .setCollectIntervalMs(snapshot.getCollectIntervalMs());
 

--- a/agent-sender/src/main/java/com/seeker/agent/sender/GrpcMetricSender.java
+++ b/agent-sender/src/main/java/com/seeker/agent/sender/GrpcMetricSender.java
@@ -1,0 +1,116 @@
+package com.seeker.agent.sender;
+
+import com.seeker.agent.core.metric.MetricSnapshot;
+import com.seeker.agent.core.sender.MetricSender;
+import com.seeker.collector.global.grpc.CollectResponse;
+import com.seeker.collector.global.grpc.CollectorServiceGrpc;
+import com.seeker.collector.global.grpc.DataMessage;
+import io.grpc.ManagedChannel;
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+
+import java.io.Closeable;
+import java.util.List;
+
+/**
+ * gRPC 스트림으로 {@link MetricSnapshot} batch를 collector에 전송하는 {@link MetricSender} 구현.
+ *
+ * <p>채널은 외부 주입(트레이스 송신과 공유)이며, <strong>자기만의 별도 stream</strong>을 연다.
+ * → 채널 자원은 1회만 맺지만, trace 폭주가 metric stream을 직접 막지 않음 (gRPC 멀티플렉싱).
+ *
+ * <p>{@code GrpcSpanTransport}와 동일한 stream 라이프사이클 패턴:
+ * <ul>
+ *   <li>lazy {@link StreamObserver} 생성</li>
+ *   <li>에러 시 {@code resetStream()}으로 다음 호출 때 재연결</li>
+ *   <li>예외 절대 throw 안 함 — 스케줄러 cycle 보호</li>
+ * </ul>
+ *
+ * <p>채널 라이프사이클은 호출자(AgentMain) 책임. 본 클래스의 {@link #close()}는 자기 stream만 정리.
+ */
+public class GrpcMetricSender implements MetricSender, Closeable {
+
+    private final GrpcMetricConverter converter;
+    private final ManagedChannel channel;
+    private final CollectorServiceGrpc.CollectorServiceStub stub;
+
+    /**
+     * lazy 생성되는 stream. 에러 시 null로 reset되고 다음 send 호출 때 재생성된다.
+     * volatile은 send와 shutdown hook 간 가시성 보장.
+     */
+    private volatile StreamObserver<DataMessage> requestObserver;
+
+    /**
+     * @param channel 외부에서 생성/소유하는 gRPC 채널. trace 송신과 공유 가능.
+     */
+    public GrpcMetricSender(ManagedChannel channel) {
+        this.channel = channel;
+        this.converter = new GrpcMetricConverter();
+        this.stub = CollectorServiceGrpc.newStub(channel);
+        System.out.println("[Seeker] GrpcMetricSender 초기화 완료 (channel authority: " + channel.authority() + ")");
+    }
+
+    @Override
+    public void send(List<MetricSnapshot> snapshots) {
+        if (snapshots == null || snapshots.isEmpty()) return;
+        try {
+            ensureStream();
+            // batch 안의 모든 snapshot을 같은 stream에 연속 push.
+            // gRPC bidirectional stream은 onNext 호출 순서를 보장한다.
+            for (MetricSnapshot s : snapshots) {
+                requestObserver.onNext(converter.toDataMessage(s));
+            }
+        } catch (Throwable t) {
+            // 절대 throw 안 함 — 스케줄러 cycle을 깨면 안 됨.
+            System.err.println("[Seeker] gRPC metric 전송 에러: " + t.getMessage());
+            resetStream();
+        }
+    }
+
+    /**
+     * stream이 없거나 reset된 상태면 새로 연다.
+     * synchronized: 일반 호출은 단일 데몬 스레드지만, shutdown hook이 close()를 동시에 호출할 수 있음.
+     */
+    private synchronized void ensureStream() {
+        if (requestObserver == null) {
+            requestObserver = stub.collect(new StreamObserver<CollectResponse>() {
+                @Override
+                public void onNext(CollectResponse value) {
+                    // collector 응답 무시 (성공 카운트는 디버그용 의미만)
+                }
+
+                @Override
+                public void onError(Throwable t) {
+                    Status status = Status.fromThrowable(t);
+                    System.err.println("[Seeker] gRPC metric 스트림 에러 - Code: " + status.getCode()
+                            + ", Description: " + status.getDescription());
+                    resetStream();
+                }
+
+                @Override
+                public void onCompleted() {
+                    resetStream();
+                }
+            });
+        }
+    }
+
+    private void resetStream() {
+        requestObserver = null;
+    }
+
+    /**
+     * 자기 stream만 정리한다. 채널은 외부 소유이므로 닫지 않음.
+     */
+    @Override
+    public void close() {
+        try {
+            StreamObserver<DataMessage> obs = requestObserver;
+            if (obs != null) {
+                obs.onCompleted();
+            }
+        } catch (Throwable ignored) {
+            // close 경로에서는 throw 금지
+        }
+        resetStream();
+    }
+}

--- a/agent-sender/src/main/java/com/seeker/agent/sender/GrpcMetricSender.java
+++ b/agent-sender/src/main/java/com/seeker/agent/sender/GrpcMetricSender.java
@@ -5,7 +5,6 @@ import com.seeker.agent.core.sender.MetricSender;
 import com.seeker.collector.global.grpc.CollectResponse;
 import com.seeker.collector.global.grpc.CollectorServiceGrpc;
 import com.seeker.collector.global.grpc.DataMessage;
-import io.grpc.ManagedChannel;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 
@@ -30,7 +29,6 @@ import java.util.List;
 public class GrpcMetricSender implements MetricSender, Closeable {
 
     private final GrpcMetricConverter converter;
-    private final ManagedChannel channel;
     private final CollectorServiceGrpc.CollectorServiceStub stub;
 
     /**
@@ -40,13 +38,13 @@ public class GrpcMetricSender implements MetricSender, Closeable {
     private volatile StreamObserver<DataMessage> requestObserver;
 
     /**
-     * @param channel 외부에서 생성/소유하는 gRPC 채널. trace 송신과 공유 가능.
+     * @param channelHolder 외부에서 생성/소유하는 gRPC 채널의 holder. trace 송신과 공유 가능.
      */
-    public GrpcMetricSender(ManagedChannel channel) {
-        this.channel = channel;
+    public GrpcMetricSender(GrpcChannelHolder channelHolder) {
         this.converter = new GrpcMetricConverter();
-        this.stub = CollectorServiceGrpc.newStub(channel);
-        System.out.println("[Seeker] GrpcMetricSender 초기화 완료 (channel authority: " + channel.authority() + ")");
+        // channel() 호출은 같은 패키지(com.seeker.agent.sender)에서만 가능 — io.grpc 캡슐화 유지.
+        this.stub = CollectorServiceGrpc.newStub(channelHolder.channel());
+        System.out.println("[Seeker] GrpcMetricSender 초기화 완료 (channel: " + channelHolder.authority() + ")");
     }
 
     @Override

--- a/agent-sender/src/main/java/com/seeker/agent/sender/GrpcSpanTransport.java
+++ b/agent-sender/src/main/java/com/seeker/agent/sender/GrpcSpanTransport.java
@@ -5,13 +5,14 @@ import com.seeker.collector.global.grpc.CollectResponse;
 import com.seeker.collector.global.grpc.CollectorServiceGrpc;
 import com.seeker.collector.global.grpc.DataMessage;
 import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 
 /**
  * gRPC 스트림으로 Span을 Collector에 전송하는 SpanTransport 구현체입니다.
- * 채널/스트림 라이프사이클과 재연결 책임을 가집니다.
+ *
+ * <p>채널은 외부에서 주입받아 다른 sender({@code GrpcMetricSender} 등)와 공유한다.
+ * 본 클래스는 자기 stream의 라이프사이클만 책임지며, channel 생성/종료는 호출자(AgentMain) 책임.
  */
 public class GrpcSpanTransport implements SpanTransport {
 
@@ -20,13 +21,14 @@ public class GrpcSpanTransport implements SpanTransport {
     private final CollectorServiceGrpc.CollectorServiceStub stub;
     private volatile StreamObserver<DataMessage> requestObserver;
 
-    public GrpcSpanTransport(String host, int port, String applicationName, String agentId) {
+    /**
+     * @param channel 외부에서 생성/소유하는 gRPC 채널. 본 클래스는 닫지 않는다.
+     */
+    public GrpcSpanTransport(ManagedChannel channel, String applicationName, String agentId) {
+        this.channel = channel;
         this.converter = new GrpcDataMessageConverter(applicationName, agentId);
-        this.channel = ManagedChannelBuilder.forAddress(host, port)
-                .usePlaintext()
-                .build();
         this.stub = CollectorServiceGrpc.newStub(channel);
-        System.out.println("[Seeker] GrpcSpanTransport 초기화 완료 (Collector: " + host + ":" + port + ")");
+        System.out.println("[Seeker] GrpcSpanTransport 초기화 완료 (channel authority: " + channel.authority() + ")");
     }
 
     @Override
@@ -69,10 +71,19 @@ public class GrpcSpanTransport implements SpanTransport {
         requestObserver = null;
     }
 
+    /**
+     * 자기 stream만 정리한다. 채널은 외부 소유이므로 닫지 않음.
+     */
     @Override
     public void close() {
-        if (channel != null) {
-            channel.shutdownNow();
+        try {
+            StreamObserver<DataMessage> obs = requestObserver;
+            if (obs != null) {
+                obs.onCompleted();
+            }
+        } catch (Throwable ignored) {
+            // close 경로에서는 throw 금지
         }
+        resetStream();
     }
 }

--- a/agent-sender/src/main/java/com/seeker/agent/sender/GrpcSpanTransport.java
+++ b/agent-sender/src/main/java/com/seeker/agent/sender/GrpcSpanTransport.java
@@ -4,31 +4,29 @@ import com.seeker.agent.core.model.Span;
 import com.seeker.collector.global.grpc.CollectResponse;
 import com.seeker.collector.global.grpc.CollectorServiceGrpc;
 import com.seeker.collector.global.grpc.DataMessage;
-import io.grpc.ManagedChannel;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 
 /**
  * gRPC 스트림으로 Span을 Collector에 전송하는 SpanTransport 구현체입니다.
  *
- * <p>채널은 외부에서 주입받아 다른 sender({@code GrpcMetricSender} 등)와 공유한다.
- * 본 클래스는 자기 stream의 라이프사이클만 책임지며, channel 생성/종료는 호출자(AgentMain) 책임.
+ * <p>채널은 {@link GrpcChannelHolder}를 통해 다른 sender({@code GrpcMetricSender} 등)와 공유한다.
+ * 본 클래스는 자기 stream의 라이프사이클만 책임지며, channel 생성/종료는 holder 측 책임.
  */
 public class GrpcSpanTransport implements SpanTransport {
 
     private final GrpcDataMessageConverter converter;
-    private final ManagedChannel channel;
     private final CollectorServiceGrpc.CollectorServiceStub stub;
     private volatile StreamObserver<DataMessage> requestObserver;
 
     /**
-     * @param channel 외부에서 생성/소유하는 gRPC 채널. 본 클래스는 닫지 않는다.
+     * @param channelHolder 외부에서 생성/소유하는 gRPC 채널의 holder. 본 클래스는 닫지 않는다.
      */
-    public GrpcSpanTransport(ManagedChannel channel, String applicationName, String agentId) {
-        this.channel = channel;
+    public GrpcSpanTransport(GrpcChannelHolder channelHolder, String applicationName, String agentId) {
         this.converter = new GrpcDataMessageConverter(applicationName, agentId);
-        this.stub = CollectorServiceGrpc.newStub(channel);
-        System.out.println("[Seeker] GrpcSpanTransport 초기화 완료 (channel authority: " + channel.authority() + ")");
+        // channel() 호출은 같은 패키지에서만 가능 — io.grpc 노출이 외부로 새지 않는다.
+        this.stub = CollectorServiceGrpc.newStub(channelHolder.channel());
+        System.out.println("[Seeker] GrpcSpanTransport 초기화 완료 (channel: " + channelHolder.authority() + ")");
     }
 
     @Override

--- a/agent-sender/src/main/java/com/seeker/agent/sender/console/ConsoleAgentInfoSender.java
+++ b/agent-sender/src/main/java/com/seeker/agent/sender/console/ConsoleAgentInfoSender.java
@@ -1,4 +1,4 @@
-package com.seeker.agent.sender;
+package com.seeker.agent.sender.console;
 
 import com.seeker.agent.core.model.AgentInfo;
 import com.seeker.agent.core.sender.AgentInfoSender;

--- a/agent-sender/src/main/java/com/seeker/agent/sender/console/ConsoleMetricSender.java
+++ b/agent-sender/src/main/java/com/seeker/agent/sender/console/ConsoleMetricSender.java
@@ -1,0 +1,35 @@
+package com.seeker.agent.sender.console;
+
+import com.seeker.agent.core.metric.Metric;
+import com.seeker.agent.core.sender.MetricSender;
+import com.seeker.agent.core.metric.MetricSnapshot;
+
+import java.util.List;
+
+/**
+ * 디버그 모드용 {@link MetricSender} 구현체.
+ * collector 통신 없이 수집된 메트릭을 콘솔에 출력한다.
+ *
+ * <p>{@code ConsoleSpanTransport}와 동일한 디버그 보조 도구. 학습/테스트 환경에서
+ * 메트릭 파이프라인 동작 확인용.
+ *
+ * <p>실제 운영에서는 gRPC 기반 구현체(Phase 1.5의 {@code GrpcMetricSender})로 교체된다.
+ */
+public class ConsoleMetricSender implements MetricSender {
+
+    public ConsoleMetricSender() {
+        System.out.println("[Seeker] ConsoleMetricSender 초기화 (collector 통신 없음)");
+    }
+
+    @Override
+    public void send(List<MetricSnapshot> snapshots) {
+        if (snapshots == null || snapshots.isEmpty()) return;
+        for (MetricSnapshot snapshot : snapshots) {
+            // batch 단위로 헤더 한 줄 + metric 목록 들여쓰기 출력. 가독성 우선.
+            System.out.println("[Seeker-DEBUG][METRIC] " + snapshot);
+            for (Metric m : snapshot.getMetrics()) {
+                System.out.println("    " + m);
+            }
+        }
+    }
+}

--- a/agent-sender/src/main/java/com/seeker/agent/sender/console/ConsoleSpanTransport.java
+++ b/agent-sender/src/main/java/com/seeker/agent/sender/console/ConsoleSpanTransport.java
@@ -1,8 +1,9 @@
-package com.seeker.agent.sender;
+package com.seeker.agent.sender.console;
 
 import com.seeker.agent.core.model.MethodType;
 import com.seeker.agent.core.model.Span;
 import com.seeker.agent.core.model.SpanEvent;
+import com.seeker.agent.sender.SpanTransport;
 
 /**
  * Span을 콘솔에 트리 형태로 출력하는 SpanTransport 구현체입니다.

--- a/agent-sender/src/main/proto/seeker.proto
+++ b/agent-sender/src/main/proto/seeker.proto
@@ -25,7 +25,8 @@ message DataMessage {
     AgentInfo agent_info = 1;
     Span span = 2;
     SpanChunk span_chunk = 3;
-    Metric metric = 4;
+    reserved 4;                          // 구버전 Metric 메시지 자리 (forward-compat 보호)
+    MetricSnapshot metric_snapshot = 5;  // Phase 1.5: 일반화된 metric batch
   }
 }
 
@@ -94,12 +95,33 @@ message SpanChunk {
 }
 
 // ----------------------------------------------------------------
-// 5. Metric Domain
+// 5. Metric Domain (Phase 1.5: 일반화된 구조)
 // ----------------------------------------------------------------
-// CPU, 메모리 등 시스템 매트릭
-message Metric {
-  int64 timestamp = 1;       // 측정 시간 (Epoch Millis)
-  double cpu_usage = 2;      // CPU 사용률 (0.0 ~ 1.0)
-  double memory_usage = 3;   // 메모리 사용률 (0.0 ~ 1.0)
-  int64 jvm_heap_used = 4;   // JVM 힙 사용량 (bytes)
+
+// 메트릭 값의 의미 — 차트/저장 측이 차분/누적/윈도우 처리를 결정하는 기준.
+enum MetricValueType {
+  GAUGE = 0;       // 폴링 시점의 현재값 (heap_used, threadCount 등)
+  CUMULATIVE = 1;  // 시작 이후 누적값. 서버에서 인접 두 시점 차분 (gc.count, classes_loaded)
+  DELTA = 2;       // 에이전트가 이미 직전 cycle 대비 차분으로 변환해 보낸 값 (transaction)
+  WINDOW = 3;      // 한 cycle 동안의 윈도우값. 다음 cycle에서 reset됨 (response_time avg/max)
+}
+
+// 한 메트릭의 한 시점 값.
+message MetricPoint {
+  string metric_name = 1;            // 카테고리 (예: "jvm.gc", "jvm.memory")
+  string field_name = 2;             // 세부 항목 (예: "count", "heap_used")
+  double value = 3;                  // 측정값
+  MetricValueType type = 4;          // 값의 의미
+  map<string, string> tags = 5;      // 차원 분해 (예: {"gc_type":"g1","gc_name":"G1 Old Generation"})
+}
+
+// 한 cycle에 수집된 메트릭의 묶음. 송신 단위.
+// 4-tuple ID = (application_name, agent_id, agent_start_time, timestamp)로 시계열을 식별한다.
+message MetricSnapshot {
+  string application_name = 1;       // 에이전트가 속한 애플리케이션
+  string agent_id = 2;               // 에이전트 인스턴스
+  int64 agent_start_time = 3;        // 에이전트 시작 시점 — 재시작 인스턴스 분리 키
+  int64 timestamp = 4;               // 이 cycle 수집 시점 (Epoch ms)
+  int64 collect_interval_ms = 5;     // wall-clock 측정된 cycle 간격 (스케줄 인터벌이 아님)
+  repeated MetricPoint points = 6;
 }

--- a/agent-sender/src/main/proto/seeker.proto
+++ b/agent-sender/src/main/proto/seeker.proto
@@ -25,8 +25,7 @@ message DataMessage {
     AgentInfo agent_info = 1;
     Span span = 2;
     SpanChunk span_chunk = 3;
-    reserved 4;                          // 구버전 Metric 메시지 자리 (forward-compat 보호)
-    MetricSnapshot metric_snapshot = 5;  // Phase 1.5: 일반화된 metric batch
+    MetricSnapshot metric_snapshot = 4;  // Phase 1.5: 일반화된 metric batch
   }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,6 +3,7 @@ rootProject.name = 'seeker-agent'
 include 'agent-bootstrap'
 include 'agent-core'
 include 'agent-instrument'
+include 'agent-metric'
 include 'agent-sender'
 include 'agent-config'
 


### PR DESCRIPTION
Resolves : #11 

## ✨ 작업 개요
# JVM 메트릭 모니터링


## 1. 왜 

### 기존 proto의 `Metric` 메시지는 다음과 같이 3개 필드 고정이었다:

```proto
message Metric {
  int64 timestamp = 1;
  double cpu_usage = 2;
  double memory_usage = 3;
  int64 jvm_heap_used = 4;
}
```

→ 새 메트릭(GC time, thread count, load average 등)을 추가할 때마다 **proto·serializer·collector·UI를 모두 건드려야** 한다. 학습 프로젝트에서도 곧바로 막히는 구조.

또한 trace 쪽은 W3C 호환까지 정리되었지만, JVM 상태(heap, GC, CPU, threads, classes)는 전혀 수집하지 않고 있어 **운영 가시성**이 부족했다.

### 1.2 목표

- Pinpoint의 검증된 패턴(단일 데몬 스레드, wall-clock interval, list-swap, GC 자동 감지 등)을 우리 구조로 옮기기
- JVM monitoring을 별도 모듈(`agent-metric`)로 분리하여 책임 명확화
- 디버그 모드에서 즉시 동작 확인 가능하도록 콘솔 송신 경로부터 마련
- **proto 변경 없이** Phase 1을 완성 (proto 일반화는 Phase 1.5로 분리하여 위험 격리)

---

## 2. 모듈 구조 — 왜 agent-metric을 새로 만들었는가

### 2.1 책임 분리 원칙

| 모듈 | 책임 | 라이브러리 의존 |
|---|---|---|
| `agent-core` | 도메인 모델 + 인터페이스 + Holder (정책 레이어) | JDK 표준만 |
| `agent-instrument` | ByteBuddy 기반 instrumentation 인프라 | ByteBuddy |
| **`agent-metric` (신규)** | **JDK MXBean 기반 metric 수집 구현체 + scheduler** | JDK 표준만 |
| `agent-sender` | 송신 구현 (gRPC/HTTP) | gRPC |
| `plugins/<lib>-plugin` | 외부 라이브러리 의존 (instrumentation/metric) | 라이브러리별 |

### 2.2 왜 core에 안 넣었는가

`JvmGcCollector` 같은 구체 collector는 JDK 표준만 의존하므로 core 첫 번째 기준은 통과. 하지만 **두 번째 기준(도메인 + 추상화만)에는 위배** — 구체 구현체를 core에 두면 모듈이 비대해지고 propagation 패턴(L1=core 추상화, L2=plugin 구현)과 일관성이 깨진다.

→ 추상화는 `agent-core`, 구현체는 `agent-metric`으로 분리.

### 2.3 의존 관계

```
agent-bootstrap ──┬──▶ agent-core
                  ├──▶ agent-metric ──▶ agent-core
                  ├──▶ agent-sender ──▶ agent-core
                  ├──▶ agent-instrument ──▶ agent-core
                  └──▶ plugins/* ──▶ agent-core
```

`agent-metric`은 **agent-core만 의존**. 인터페이스(`MetricCollector`, `MetricSender`)와 도메인(`Metric`, `MetricSnapshot`)을 core에서 가져와 구현체를 제공.

---

## 3. agent-core 클래스의 필드 의미


### 3.1 `MetricValueType` (enum)

메트릭 값의 의미를 명시하는 enum. 차트/저장 측이 이 값을 보고 어떻게 다룰지 결정한다.

| 값 | 의미 | 예시 | 차트/서버 처리 |
|---|---|---|---|
| `GAUGE` | 폴링 시점의 현재값 | heap_used, threadCount, cpu_load | 그대로 표시 |
| `CUMULATIVE` | 누적값. 인접 두 시점 차분이 의미 | gc_count, classes_loaded | **서버에서 차분** |
| `DELTA` | 에이전트가 이미 직전 cycle 대비 차분으로 변환한 값 | transaction count | 그대로 표시(이미 차분됨) |
| `WINDOW` | 한 cycle 동안의 윈도우값. 다음 cycle에서 reset됨 | response_time avg/max | 그대로 표시 |

**왜 enum으로 강제하는가:** Pinpoint는 metric 이름으로 서버가 추론하는 비공식 규약이지만, 본 에이전트는 wire 필드로 명시하여 차트의 추론 부담을 제거한다.

### 3.2 `Metric`

한 메트릭의 한 시점 값을 표현하는 불변 도메인 객체.

| 필드 | 타입 | 의미 |
|---|---|---|
| `metricName` | `String` | 카테고리 (예: `"jvm.gc"`, `"jvm.memory"`, `"system.cpu"`). 같은 카테고리 내 여러 fieldName이 모임. |
| `fieldName` | `String` | 카테고리 내 세부 항목 (예: `"heap_used"`, `"count"`, `"jvm_load"`). 차트에서는 `metricName.fieldName`을 합쳐 표시. |
| `value` | `double` | 측정값. byte(heap_used) / 횟수(count) / 비율(jvm_load 0~1) / ms(time_ms) 등 단위는 fieldName으로 추론. |
| `type` | `MetricValueType` | 값의 의미 (4.1 참조) |
| `timestamp` | `long` | 수집 시각 (Epoch ms). 한 cycle의 모든 metric은 동일 timestamp를 공유 (호출자 `MetricRegistry`가 보장). |
| `tags` | `Map<String,String>` | 차원 분해용 키-값. 예: `{gc_type:"g1", gc_name:"G1 Old Generation"}` — 같은 fieldName도 tag로 시리즈 분리 가능. 비어있으면 `Collections.emptyMap()`. immutable. |

**팩토리 메서드:** `Metric.gauge(...)`, `Metric.cumulative(...)`, `Metric.delta(...)`, `Metric.window(...)` — 호출 코드를 짧게 만들고 잘못된 type 지정을 어렵게 만든다.

### 3.3 `MetricSnapshot`

한 cycle에 수집된 모든 메트릭의 묶음. 송신 단위.

| 필드 | 타입 | 의미 |
|---|---|---|
| `applicationName` | `String` | 에이전트가 속한 애플리케이션 이름 (`AgentInfo.agentName`과 동일). 같은 앱의 여러 인스턴스(agentId)를 묶어 비교할 때 사용. |
| `agentId` | `String` | 에이전트 인스턴스 식별자. 같은 앱 내 다른 호스트/프로세스 구분. |
| `agentStartTime` | `long` | **에이전트 시작 시각** (Epoch ms). 같은 agentId라도 이 값이 다르면 **재시작된 다른 인스턴스로 취급**되어 시계열이 분리된다. Pinpoint의 4-tuple 키 핵심 — 재배포/재시작을 차트에 명확히 표현. |
| `timestamp` | `long` | 이 cycle의 수집 시점 (Epoch ms). |
| `collectIntervalMs` | `long` | **wall-clock measured** cycle 간 경과 시간. ★ 스케줄러 인터벌(예: 5000ms)이 아니라 실제 측정값. GC pause로 8초가 됐으면 8000을 보냄. 서버의 TPS 계산이 정확해지는 핵심 인사이트 (Pinpoint 차용). 첫 cycle은 0. |
| `metrics` | `List<Metric>` | 이 cycle에 수집된 모든 metric. immutable list. 비어있을 수 있음. |

**4-tuple ID** = (`applicationName`, `agentId`, `agentStartTime`, `timestamp`). 이 4개로 시계열 측정점이 유일하게 식별된다.

**팩토리:** `MetricSnapshot.of(agentInfo, timestamp, intervalMs, metrics)` — `AgentInfo`에서 식별 정보 3개를 자동으로 채움.

### 3.4 `MetricCollector` (인터페이스)

단일 메트릭 종류(JVM GC, JVM Memory, System CPU 등)를 수집하는 책임.

| 메서드 | 시그니처 | 의미 |
|---|---|---|
| `name()` | `String` | 컬렉터의 식별 이름. 로그 출력 시 어느 collector가 실패했는지 추적용. 예: `"jvm.gc"` |
| `isAvailable()` | `boolean` | 현재 환경에서 이 컬렉터가 동작 가능한지. JDK/벤더 메서드가 없으면 false 반환. **graceful degradation을 인터페이스에 강제** — Pinpoint도 못한 부분. |
| `collect(long now)` | `List<Metric>` | 한 시점의 메트릭들을 수집해 반환. `null` 반환 금지 (빈 리스트 반환). 호출자가 전달한 `now`를 모든 metric의 timestamp로 사용해야 한 cycle 내 일관성 유지. |

**구현 원칙:**
- MXBean은 부팅 시 1회 lookup하고 인스턴스 캐싱 (매 cycle 새로 lookup 금지)
- `collect()`은 가능하면 throw하지 않음 — 호출자(`MetricRegistry`)도 잡지만 안전망 이중화

### 3.5 `MetricRegistry`

모든 `MetricCollector`를 모아 한 번에 수집하는 composite.

| 필드/메서드 | 타입 | 의미 |
|---|---|---|
| `collectors` (필드) | `CopyOnWriteArrayList<MetricCollector>` | 등록된 컬렉터들. CoW 채택 이유: 등록은 부팅 시만 일어나고 순회(매 cycle)는 락 없이 빠르게 해야 하므로. |
| `register(c)` | `void` | 컬렉터 추가. `isAvailable()`이 false면 무시 + 로그. dead collector를 사전 차단. |
| `collectAll(now)` | `List<Metric>` | 모든 등록된 컬렉터에서 수집. **per-collector try-catch**로 한 컬렉터 실패가 다른 컬렉터를 막지 않게 격리. (Pinpoint Composite 패턴) |
| `size()` | `int` | 등록된 컬렉터 수. 디버깅/로그용. |

**격리 정책:** 모니터링 실패가 비즈니스 앱에 영향을 주는 일은 절대 없어야 한다 — 그래서 `Throwable`까지 catch하고 stderr로 로그만 남기고 다음 컬렉터로 진행.

### 3.6 `MetricSender` (인터페이스)

수집된 `MetricSnapshot`을 외부로 내보내는 책임.

| 메서드 | 시그니처 | 의미 |
|---|---|---|
| `send(snapshots)` | `void send(List<MetricSnapshot>)` | batch로 묶인 스냅샷들을 송신. 절대 throw 하지 않을 것 — 스케줄러 cycle을 깨뜨리면 안 됨. blocking 호출은 짧게 (길면 다음 cycle 밀림). |

**구현체:**
- `ConsoleMetricSender` (현재) — 디버그 모드 콘솔 출력
- `GrpcMetricSender` (Phase 1.5) — `GrpcMetricConverter`로 proto 변환 + 자체 channel/stream으로 gRPC 송신

---

## 4. agent-metric 클래스 역할 상세

### 4.1 `GcTypeDetector`

JVM GC 알고리즘을 `GarbageCollectorMXBean.getName()` 문자열로 자동 매칭.

**enum `GcType`**: SERIAL / PARALLEL / CMS / G1 / ZGC / SHENANDOAH / UNKNOWN

**`classify(name)`**: bean 이름 → GcType 분류. 예:
- `"G1 Old Generation"` → `G1`
- `"ZGC Major Pauses"` → `ZGC`
- `"PS Scavenge"` → `PARALLEL`
- 매칭 실패 → `UNKNOWN` (Pinpoint의 graceful fallback 패턴)

→ `JvmGcCollector`가 GC count/time을 보낼 때 tag로 함께 실어 차트에서 GC 종류별 시리즈 분리 가능.

### 4.2 `JvmMemoryCollector`

`MemoryMXBean`으로 heap/non-heap 사용량 수집.

**측정 항목:**

| 메트릭 | type | 의미 |
|---|---|---|
| `jvm.memory.heap_used` | GAUGE | 현재 사용 중 (byte) |
| `jvm.memory.heap_committed` | GAUGE | JVM이 OS로부터 확보한 힙 |
| `jvm.memory.heap_max` | GAUGE | 최대치. **`-1`이면 committed로 fallback** (ZGC Metaspace 등 unbounded pool 보호 — Pinpoint:78 패턴) |
| `jvm.memory.nonheap_used/committed/max` | GAUGE | Metaspace/CodeCache 등 |

### 4.3 `JvmGcCollector`

`GarbageCollectorMXBean`으로 GC 누적값 수집.

**측정 항목:**

| 메트릭 | type | tags |
|---|---|---|
| `jvm.gc.count` | CUMULATIVE | `{gc_type, gc_name}` |
| `jvm.gc.time_ms` | CUMULATIVE | `{gc_type, gc_name}` |

서버가 인접 두 시점 차분으로 "최근 5초간 GC 5회, 50ms" 같은 차트 표시.

### 4.4 `JvmThreadCollector`

`ThreadMXBean`으로 스레드 통계 수집.

| 메트릭 | type | 의미 |
|---|---|---|
| `jvm.thread.count` | GAUGE | 현재 스레드 수 |
| `jvm.thread.daemon_count` | GAUGE | 데몬 스레드 수 |
| `jvm.thread.peak_count` | GAUGE | 시작 이후 피크 |
| `jvm.thread.total_started_count` | CUMULATIVE | 누적 생성 스레드 — 우상향이 지속되면 스레드 leak 의심 |

### 4.5 `JvmClassCollector`

`ClassLoadingMXBean`으로 클래스 로딩 통계.

| 메트릭 | type | 의미 |
|---|---|---|
| `jvm.class.loaded_count` | GAUGE | 현재 로드된 |
| `jvm.class.total_loaded_count` | CUMULATIVE | 누적 로드 — 운영 중 계속 증가하면 동적 클래스 생성(예: dynamic proxy 폭증) 의심 신호 |
| `jvm.class.unloaded_count` | CUMULATIVE | 누적 언로드 |

### 4.6 `SystemCpuCollector`

`OperatingSystemMXBean`의 vendor 확장 메서드를 **reflection으로 호출** — Oracle/OpenJDK 외 일부 JDK(IBM J9 등)에서 메서드가 없을 수 있어 graceful degradation을 위해 직접 cast 대신 reflection 사용.

| 메트릭 | type | 의미 |
|---|---|---|
| `system.cpu.jvm_load` | GAUGE | JVM 프로세스 CPU 사용률 (0.0~1.0) |
| `system.cpu.system_load` | GAUGE | 시스템 전체 CPU 사용률 (0.0~1.0) |
| `system.cpu.load_average` | GAUGE | system load average ÷ CPU 코어 수 (Unix 전용, 1.0=100% 부하로 정규화) |

**JDK 14+ 호환:** `getSystemCpuLoad`(deprecated) → `getCpuLoad`로 메서드 이름이 바뀌어, 둘 다 시도해서 먼저 발견된 것 사용. 한 메트릭이 빠져도 나머지는 정상 수집.

### 4.7 `MetricScheduler`

수집 cycle을 주기적으로 실행하고 batch로 송신. **Pinpoint의 `DefaultAgentStatMonitor` + `CollectJob` 패턴 차용.**

**핵심 필드:**

| 필드 | 의미 |
|---|---|
| `executor` | 단일 데몬 스레드 ScheduledExecutor. 스레드 이름 `seeker-stat-monitor` (jstack 식별성). 데몬 — 이 스레드가 살아있어 JVM 종료를 막는 일 방지. |
| `intervalMs` | 수집 주기. `[1000, 10000]`으로 clamp — 너무 짧으면 부하, 너무 길면 dashboard 무의미. |
| `batchSize` | N cycle 누적 후 flush. default 6 (5초 인터벌 × 6 = 30초마다 송신). gRPC 호출 횟수 절감. |
| `prevTimestamp` | 직전 cycle의 timestamp. **wall-clock measured interval** 계산용 (`now - prevTimestamp`). |
| `buffer` | N cycle 누적 버퍼. flush 시 `new ArrayList`로 swap, 기존 리스트는 sender에 양도. **list-swap 패턴 — lock 없이 producer/consumer 분리.** |

**주요 동작 패턴:**

1. **pre-load class trick**: `start()` 직전 `collectAll()` 2회 미리 호출. Pinpoint #2881 회피용 안전 보험 (스케줄러 첫 cycle에 일어나는 클래스 로딩이 비즈니스 스레드와 충돌하지 않도록 사전 워밍업).
2. **per-cycle try-catch**: 한 cycle 실패가 다음 cycle을 막지 않음.
3. **shutdown hook**: JVM 종료 시 잔여 버퍼 flush + executor 정리.

---

## 5. 와이어링 (`AgentMain`)

채널을 1개만 만들어 trace·metric 송신기가 공유한다. 각자 자기 stream만 보유.

```java
// premain() 안에서:

// 정상 모드면 공유 gRPC 채널 1개 생성.
final ManagedChannel grpcChannel = debugEnabled
        ? null
        : ManagedChannelBuilder
                .forAddress(collectorConfig.getHost(), collectorConfig.getGrpcPort())
                .usePlaintext()
                .build();

// trace 송신기 — 공유 채널 위에 자기 stream
SpanTransport transport = debugEnabled
        ? new ConsoleSpanTransport()
        : new GrpcSpanTransport(grpcChannel,
                                identityConfig.getAgentName(), identityConfig.getAgentId());

// 메트릭 시스템 가동 (공유 채널을 그대로 넘김)
if (profilerConfig.isMetricEnabled()) {
    startMetricMonitor(profilerConfig, grpcChannel, debugEnabled, agentInfo);
}

// 채널 라이프사이클 hook — 가장 마지막에 등록되어 가장 먼저(또는 병렬로) 실행.
// 두 sender의 close()는 자기 stream만 정리하고 채널은 안 닫으므로 여기서 일괄 종료.
if (grpcChannel != null) {
    Runtime.getRuntime().addShutdownHook(new Thread(() -> {
        grpcChannel.shutdown();
        if (!grpcChannel.awaitTermination(2, TimeUnit.SECONDS)) {
            grpcChannel.shutdownNow();
        }
    }, "seeker-grpc-shutdown"));
}
```

```java
private static void startMetricMonitor(ProfilerConfig profilerConfig,
                                       ManagedChannel grpcChannel,    // ← 공유 채널 주입
                                       boolean debugEnabled,
                                       AgentInfo agentInfo) {
    MetricRegistry registry = new MetricRegistry();
    registry.register(new JvmGcCollector());
    registry.register(new JvmMemoryCollector());
    registry.register(new JvmThreadCollector());
    registry.register(new JvmClassCollector());
    registry.register(new SystemCpuCollector());

    MetricSender metricSender = debugEnabled
            ? new ConsoleMetricSender()
            : new GrpcMetricSender(grpcChannel);    // ← 채널만 받고 자기 stream 생성

    MetricScheduler scheduler = new MetricScheduler(
            registry, metricSender, agentInfo,
            profilerConfig.getMetricIntervalMs(),
            profilerConfig.getMetricBatchSize());
    scheduler.start();

    // shutdown 순서:
    //   1) scheduler.stop()  — 잔여 버퍼 flush 시도 (이때 sender.send 마지막 호출 가능)
    //   2) sender.close()    — 자기 stream만 정리. 채널은 별도 hook이 닫음.
    Runtime.getRuntime().addShutdownHook(new Thread(() -> {
        scheduler.stop();
        if (metricSender instanceof java.io.Closeable) {
            try { ((java.io.Closeable) metricSender).close(); } catch (Exception ignored) {}
        }
    }, "seeker-stat-shutdown"));
}
```

**`ProfilerConfig` 신규 키:**

| Properties 키 | 기본값 | 의미 |
|---|---|---|
| `seeker.metric.enabled` | `true` | metric 수집 전체 on/off |
| `seeker.metric.interval.ms` | `5000` | cycle 주기. `[1000, 10000]`로 클램프됨 |
| `seeker.metric.batch.size` | `6` | N cycle 누적 후 flush |

---

## 6. 전체 플로우 (자세히)

이 절은 시스템이 **부팅 → 정상 cycle → flush → 종료**까지 어떻게 흐르는지, 그리고 어디서 장애가 격리되는지를 시퀀스로 풀어 설명한다.

### 6.1 부팅 플로우 (premain → 메트릭 시스템 가동)

```
[JVM 시작]
    │
    ▼
AgentMain.premain(agentArgs, inst)
    │
    ├─ PropertiesLoader.load()                      ← 설정 파일 읽기
    ├─ ProfilerConfig 생성                           ← seeker.metric.* 키 파싱
    │
    ├─ AgentInfo 생성 (agentId, agentName, agentStartTime=now)
    ├─ AgentInfoSender.register(agentInfo)          ← collector에 에이전트 등록
    ├─ AgentInfoHolder.set(agentInfo)               ← 인터셉터/scheduler 공유
    │
    ├─ TraceContextHolder, PropagatorHolder 등록     ← trace 쪽
    ├─ DataSenderHolder 등록 + Span 송신기 가동      ← trace 쪽
    │
    ├─ engine.install(inst)                         ← ByteBuddy instrumentation 설치
    │
    └─ if (profilerConfig.isMetricEnabled())
          startMetricMonitor(profilerConfig, debugEnabled, agentInfo)
              │
              ├─ MetricRegistry 생성
              ├─ JvmGcCollector()        ← 생성자에서 GC bean 1회 lookup, 캐싱
              ├─ JvmMemoryCollector()    ← MemoryMXBean 캐싱
              ├─ JvmThreadCollector()    ← ThreadMXBean 캐싱
              ├─ JvmClassCollector()     ← ClassLoadingMXBean 캐싱
              ├─ SystemCpuCollector()    ← OS bean + reflection 메서드 캐싱
              │       │
              │       └─ 각 register() 시 isAvailable() 검사
              │           └─ false면 등록 거부 + 로그
              │
              ├─ ConsoleMetricSender 생성
              ├─ MetricScheduler 생성
              │       └─ ScheduledExecutorService 생성
              │           └─ Thread name="seeker-stat-monitor", daemon=true
              │
              ├─ scheduler.start()
              │       │
              │       ├─ pre-load class trick: collectAll() × 2 (#2881 회피)
              │       └─ executor.scheduleAtFixedRate(runOnce, interval, interval)
              │
              └─ Runtime.addShutdownHook(scheduler::stop)
                                                     ↓
                    [premain 종료, JVM 본 코드 시작]
                                                     ↓
                  매 interval ms마다 runOnce() 호출됨
```

**핵심 시점 정리:**
- **부팅 1회만 일어나는 비용**: MXBean lookup, reflection 메서드 lookup, register 시 `isAvailable()` 검사, pre-load
- **`agentStartTime`은 부팅 시 1회 fix**: 이 값이 4-tuple ID의 핵심. 재시작 시 새 값으로 시계열 분리
- **shutdown hook 등록**: JVM 정상 종료 시 잔여 버퍼를 flush

### 6.2 한 cycle 처리 흐름 (`runOnce()`가 호출될 때)

스케줄러 스레드(`seeker-stat-monitor`)에서 단일 호출되므로 락 없음.

```
[ScheduledExecutor가 매 interval ms마다 호출]
    │
    ▼
MetricScheduler.runOnce()
    │
    │  try {
    │
    ├─ now = System.currentTimeMillis()
    │
    ├─ measuredInterval = (prevTimestamp < 0) ? 0 : (now - prevTimestamp)
    │       │
    │       └─ ★ wall-clock measured. 스케줄 인터벌(5000ms)이 아닌 실제 경과.
    │           GC pause로 8초가 됐으면 8000을 보냄.
    │
    ├─ prevTimestamp = now
    │
    ├─ registry.collectAll(now)                    ← (7.3 참조)
    │       │
    │       └─ List<Metric> [모든 collector 결과 합침]
    │
    ├─ MetricSnapshot.of(agentInfo, now, measuredInterval, metrics)
    │       │
    │       └─ 4-tuple ID 자동 채움 + 모든 metric이 같은 timestamp 공유
    │
    ├─ buffer.add(snapshot)
    │
    └─ if (buffer.size() >= batchSize)
          flush()                                  ← (7.4 참조)
    │
    │  } catch (Throwable t) {
    │      // 한 cycle 실패가 다음 cycle을 막지 않음
    │      System.err.println("[Seeker] metric cycle failed: " + t)
    │  }
    │
    ▼
   [return — 다음 interval ms 대기]
```

**왜 wall-clock measured인가:** 스케줄러 인터벌이 5000ms로 설정되어 있어도, JVM이 GC pause를 8초 했다면 실제 cycle 간격은 8초+다. 이때 8000을 보내야 서버가 "최근 8초간 GC 5회 = 0.625회/초" 정확한 TPS 계산 가능. 5000으로 신뢰하면 비율이 왜곡됨.

### 6.3 collector 한 개의 `collect()` 흐름 (예: `JvmGcCollector`)

`MetricRegistry.collectAll(now)`이 각 collector를 순회하면서 호출. 한 collector가 throw해도 다른 collector는 영향 없음.

```
MetricRegistry.collectAll(now)
    │
    │  List<Metric> all = new ArrayList<>()
    │
    │  for (MetricCollector c : collectors)
    │      try {
    │          metrics = c.collect(now)            ↓ 여기서 collector별 동작
    │          all.addAll(metrics)
    │      } catch (Throwable t) {
    │          // per-collector 격리 — 한 collector 실패가 전체 cycle을 망치지 않음
    │          System.err.println("collector failed: " + c.name())
    │      }
    │
    └─ return all
```

**`JvmGcCollector.collect(now)` 내부:**
```
JvmGcCollector.collect(now)
    │
    │  for (GarbageCollectorMXBean bean : gcBeans)   ← 부팅 시 캐싱된 list
    │      ├─ tags = {gc_type: GcTypeDetector.classify(bean.getName()).label(),
    │      │          gc_name: bean.getName()}
    │      │
    │      ├─ Metric.cumulative("jvm.gc", "count", bean.getCollectionCount(), now, tags)
    │      └─ Metric.cumulative("jvm.gc", "time_ms", bean.getCollectionTime(), now, tags)
    │
    └─ return List<Metric> [GC bean 수 × 2개]
```

**예: G1 GC 환경**
- bean[0] = "G1 Young Generation" → Metric "jvm.gc.count" tags={g1, "G1 Young Generation"}
- bean[0] = "G1 Young Generation" → Metric "jvm.gc.time_ms" tags={g1, "G1 Young Generation"}
- bean[1] = "G1 Old Generation" → Metric "jvm.gc.count" tags={g1, "G1 Old Generation"}
- bean[1] = "G1 Old Generation" → Metric "jvm.gc.time_ms" tags={g1, "G1 Old Generation"}

→ 차트에서 `gc_name` tag로 Young/Old 분리, `gc_type`으로 알고리즘 시리즈 분리 가능.

### 6.4 flush 흐름 (`buffer`가 `batchSize` 도달)

list-swap 패턴으로 **락 없이** producer/consumer 분리.

```
MetricScheduler.flush()
    │
    │  if (buffer.isEmpty()) return
    │
    ├─ List<MetricSnapshot> toSend = buffer        ← 기존 리스트 참조 양도
    │
    ├─ buffer = new ArrayList<>(batchSize)         ← ★ 새 인스턴스로 swap
    │       │                                         이 시점 이후 다음 cycle은
    │       │                                         새 buffer에만 누적됨
    │
    │  try {
    ├─    sender.send(toSend)                      ← (7.4.a 참조)
    │  } catch (Throwable t) {
    │      // sender도 throw 안 하지만 안전망
    │      System.err.println("metric send failed: " + t)
    │  }
    │
    └─ return
```

**왜 list-swap인가:**
- 락 없이 producer(scheduler 스레드)와 consumer(sender 동작)가 다른 객체를 참조
- 일반적인 큐는 동시성 제어 비용이 있는데, swap은 단순 참조 교체라 비용 0
- Pinpoint에서 가져온 핵심 패턴 (`CollectJob.sendAgentStats()`)

#### 6.4.a `ConsoleMetricSender.send(snapshots)` (현재 구현)

```
ConsoleMetricSender.send(snapshots)
    │
    │  for (MetricSnapshot snapshot : snapshots)
    │      ├─ System.out.println("[Seeker-DEBUG][METRIC] " + snapshot)
    │      │       │
    │      │       └─ "MetricSnapshot{agent=test-agent ts=170... interval=5012ms count=22}"
    │      │
    │      └─ for (Metric m : snapshot.getMetrics())
    │            └─ System.out.println("    " + m)
    │                    │
    │                    └─ "Metric{jvm.gc.count=42.0 (CUMULATIVE) tags={gc_type=g1, ...} ts=170...}"
    │
    └─ return
```

#### 6.4.b `GrpcMetricSender.send(snapshots)` (Phase 1.5 구현)

```
GrpcMetricSender.send(snapshots)
    │
    │  try {
    ├─    ensureStream()                                 ← 첫 호출 또는 reset 후 stream 생성
    │     │
    │     └─ stub.collect(streamObserver) → requestObserver
    │
    │  for (MetricSnapshot snapshot : snapshots)
    │      ├─ converter.toDataMessage(snapshot)          ← GrpcMetricConverter
    │      │   ├─ MetricSnapshot.Builder
    │      │   │     .setApplicationName / .setAgentId / .setAgentStartTime
    │      │   │     .setTimestamp / .setCollectIntervalMs
    │      │   ├─ for each Metric:
    │      │   │     toProtoPoint(m)
    │      │   │       ├─ MetricPoint.Builder
    │      │   │       │     .setMetricName / .setFieldName / .setValue
    │      │   │       │     .setType (도메인 enum → proto enum 매핑)
    │      │   │       │     .putAllTags(m.getTags())
    │      │   │       └─ build()
    │      │   └─ DataMessage.newBuilder().setMetricSnapshot(...).build()
    │      │
    │      └─ requestObserver.onNext(dataMessage)        ← gRPC bidirectional stream으로 push
    │
    │  } catch (Throwable t) {
    │      // 절대 throw 안 함. 다음 호출에 stream 재생성하도록 reset.
    │      System.err.println("[Seeker] gRPC metric 전송 에러: " + t.getMessage());
    │      resetStream();
    │  }
    │
    └─ return
```

**채널 공유 + 스트림 분리 설계:**
- `ManagedChannel`은 `AgentMain`에서 1개만 생성하여 `GrpcSpanTransport`와 `GrpcMetricSender`가 **공유**. 인증/세션·소켓·DNS lookup 비용을 한 번만 부담.
- 두 sender는 같은 채널 위에 **자기 stream**을 따로 연다 (`stub.collect(...)`를 각자 호출). gRPC bidirectional stream은 한 채널 위에 다중으로 다중화 가능 — trace stream과 metric stream이 독립적으로 흘러간다.
- 효과: 채널 자원은 절약, 스트림 레벨 격리는 유지. trace stream에 onError가 나도 metric stream은 영향 없음 (그 반대도).
- 송신은 단일 데몬 스레드(`seeker-stat-monitor`)에서만 호출 → 락 거의 불필요. `requestObserver`만 volatile + ensureStream만 synchronized로 shutdown hook 동시 호출 방어.
- 채널 라이프사이클은 `AgentMain`이 책임 — 두 sender의 `close()`는 자기 stream만 정리(`onCompleted`)하고, 채널 자체는 별도 hook(`seeker-grpc-shutdown`)에서 마지막에 종료.

### 6.5 종료 플로우 (JVM shutdown)

```
[JVM이 종료 신호 수신: SIGTERM, System.exit(), main 끝 등]
    │
    ▼
shutdown hooks 실행 (등록된 순서대로 병렬)
    │
    ├─ "seeker-stat-shutdown" 스레드에서 scheduler.stop() 호출
    │       │
    │       ├─ future.cancel(false)                 ← 다음 예약된 runOnce 취소
    │       │
    │       ├─ executor.shutdown()                  ← 새 작업 거부, 진행 중 작업은 완료 대기
    │       │
    │       ├─ executor.awaitTermination(2초)
    │       │       └─ 2초 안에 안 끝나면 shutdownNow() (강제 인터럽트)
    │       │
    │       └─ flush()                              ← 마지막 잔여 버퍼 송신 (best-effort)
    │
    └─ (다른 hook들도 병렬로 실행)
                                                     ↓
                  [모든 hook 완료 → JVM 프로세스 종료]
```

**보장하는 것:**
- 진행 중이던 cycle은 끝까지 진행
- 버퍼에 쌓여있던 미전송 snapshot이 마지막으로 한 번 더 flush 시도

**보장하지 않는 것:**
- `kill -9` 같은 강제 종료 → shutdown hook 안 돌고 즉사. 버퍼 손실.
- gRPC 송신이 2초보다 오래 걸리면 잘림. 운영에선 awaitTermination 시간을 늘리는 옵션 검토 필요.

### 6.6 장애 격리 흐름 (4중 try-catch)

모니터링 실패가 비즈니스 앱에 영향을 주지 않도록 **4단계로 try-catch가 중첩**되어 있다.

```
1차) 각 collector 자체적으로 (옵션, 권장)
       ↓
2차) MetricRegistry.collectAll() — per-collector try-catch
       ↓
3차) MetricScheduler.runOnce() — per-cycle try-catch
       ↓
4차) MetricScheduler.flush() — sender try-catch
```

**시나리오별 격리 동작:**

| 장애 시나리오 | 격리되는 위치 | 영향 |
|---|---|---|
| `SystemCpuCollector`가 reflection으로 호출한 메서드 throw | 2차 (Registry) | 다른 4개 collector는 정상. 다음 cycle도 정상. |
| `JvmGcCollector`가 NullPointerException | 2차 (Registry) | 다른 collector 정상. CPU/Memory/Thread/Class metric은 그대로 송신됨. |
| `MetricSnapshot.of()`가 NPE (예: agentInfo가 null) | 3차 (runOnce) | 이 cycle 결과만 손실. 다음 cycle은 정상. |
| `ConsoleMetricSender`가 IOException (파이프 깨짐 등) | 4차 (flush) | buffer는 이미 swap된 상태. 다음 batch는 새 buffer로 정상 시도. |
| 네트워크 단절로 `GrpcMetricSender`가 hang | (격리 안 됨, 알려진 한계) | flush 호출이 block되면 다음 runOnce가 밀림. 추후 timeout 정책 필요. |
| collector 안에서 무한 루프 | (격리 안 됨, 한계) | scheduler 스레드 자체가 멈춤. 다음 cycle 안 돌음. |
| `OutOfMemoryError` | (격리 못 함) | JVM 전체 영향. 별도 정책 필요(스케줄러 자체가 OOM 안 나도록 buffer 크기 가드). |

→ 일반적 예외/오류는 1~4차에서 모두 잡혀 비즈니스 앱에 영향 없음. 격리 안 되는 케이스는 대부분 hang/OOM류로, 운영 단계에서 별도 모니터링과 정책으로 보강.

### 6.7 데이터 모델의 흐름 (한 측정값이 어디서 어디까지 가는가)

`heap_used` 값 하나가 부트스트랩에서 콘솔 출력까지 거치는 단계:

```
[JVM 내부]
    MemoryMXBean.getHeapMemoryUsage().getUsed()
                    │
                    ▼ long 12345678
                    │
[JvmMemoryCollector.collect(now)]
    Metric.gauge("jvm.memory", "heap_used", 12345678, now)
                    │
                    ▼ Metric{...} (불변 값 객체)
                    │
[MetricRegistry.collectAll(now)]
    List<Metric> [all 22개 정도]                 ← 5개 collector 결과 합침
                    │
                    ▼
[MetricScheduler.runOnce()]
    MetricSnapshot.of(agentInfo, now, intervalMs, metrics)
                    │
                    ▼ MetricSnapshot{appName, agentId, agentStartTime, ts, interval, [22 metrics]}
                    │
[buffer.add(snapshot)]
    List<MetricSnapshot> [1개, 2개, ... 6개]      ← batchSize 도달까지 누적
                    │
                    ▼ batchSize 도달 시
                    │
[MetricScheduler.flush() → list-swap]
    toSend = buffer (6개 snapshot)
    buffer = new ArrayList()                     ← 새 인스턴스로 producer/consumer 분리
                    │
                    ▼
[sender.send(toSend)]
    ConsoleMetricSender → System.out.println(...)
                    │
                    ▼
[정상 모드: GrpcMetricSender (Phase 1.5)]
    converter.toDataMessage(snapshot) → DataMessage proto
    requestObserver.onNext(...) → gRPC stream → collector → DB
```

**timestamp 일관성:** `MetricRegistry.collectAll(now)`이 받은 `now` 하나가 그 cycle의 모든 metric에 동일하게 박힘 → 같은 cycle의 GC count와 heap_used가 같은 시점 값임을 보장. 그렇지 않으면 cycle 내부에서 시간이 살짝 어긋나 보일 수 있음.

**`agentStartTime` 일관성:** 부트스트랩 시 1회 결정된 값을 모든 snapshot이 공유 → 재시작 전후 시계열이 깔끔하게 분리됨.

---

## 7. Pinpoint에서 차용한 패턴 정리

| Pinpoint 패턴 | 채택 위치 |
|---|---|
| 단일 데몬 스레드 + jstack 식별성 있는 이름 | `MetricScheduler.executor` |
| 인터벌 [1s, 10s] clamp | `MetricScheduler` 생성자 |
| wall-clock measured `collectIntervalMs` | `MetricScheduler.runOnce()` |
| N cycle 누적 후 batch flush + list-swap | `MetricScheduler.flush()` |
| pre-load class trick (#2881) | `MetricScheduler.start()` |
| MXBean 부팅 시 1회 lookup, 캐싱 | 모든 `Jvm*Collector` 생성자 |
| GC 알고리즘 자동 감지 + Unknown fallback | `GcTypeDetector` |
| `max == -1` → `committed` fallback | `JvmMemoryCollector` |
| per-cycle try-catch + per-collector try-catch (이중 격리) | `MetricRegistry` + `MetricScheduler` |
| vendor 분기 (reflection 기반 graceful degradation) | `SystemCpuCollector` |
| 4-tuple ID (app, agent, agentStartTime, timestamp) | `MetricSnapshot` |

**Pinpoint 능가:**
- `MetricValueType` enum 강제 — Pinpoint는 metric 이름으로 추론, 우리는 wire 필드로 명시
- `MetricCollector.isAvailable()` 인터페이스에 박아 graceful degradation을 모든 컬렉터에 강제 (Pinpoint는 vendor 분기 시만 적용)

---



## ✅ 체크리스트

- [x] 로컬에서 빌드 및 테스트를 통과했습니다.
- [x] 관련 문서를 업데이트했습니다. (필요한 경우)
- [x] 리뷰어가 확인하기 쉽도록 변경 사항을 정리했습니다.

## 💬 리뷰어에게

<!-- 집중해서 봐주셨으면 하는 부분이나 참고할 내용을 적어주세요. -->
